### PR TITLE
Embed core CAPI provider  components manifest in Turtles chart

### DIFF
--- a/charts/rancher-turtles/templates/core-provider-airgapped.yaml
+++ b/charts/rancher-turtles/templates/core-provider-airgapped.yaml
@@ -1,0 +1,2 @@
+{{- if and (index .Values "cluster-api-operator" "cluster-api" "enabled") (index .Values "rancherTurtles" "airGapped") }}
+{{- end }}


### PR DESCRIPTION
This PR fetches core CAPI  components manifest from release and embeds the template in the Turtles chart for a simplified air-gapped installation.