### PR TITLE
Embed core CAPI provider latest components manifest in Turtles chart

### DIFF
--- a/.github/scripts/fetch-core-capi.sh
+++ b/.github/scripts/fetch-core-capi.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# script-specific variables
+CAPI_VERSION="${CAPI_VERSION:-latest}"
+CAPI_RELEASE_URL="${CAPI_RELEASE_URL:-https://github.com/rancher-sandbox/cluster-api/releases/${CAPI_VERSION}/core-components.yaml}"
+OUTPUT_DIR="${OUTPUT_DIR:-/tmp}"
+CLUSTERCTL_DOWNLOAD_URL="${CAPI_UPSTREAM_URL:-https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPI_VERSION}/clusterctl-linux-amd64}"
+CLUSTERCTL_CONFIG_PATH="${CLUSTERCTL_CONFIG_PATH:-/tmp/clusterctl.yaml}"
+COMMIT_MSG="chore: embed core CAPI ${CAPI_VERSION} in Turtles chart"
+
+cat >${CLUSTERCTL_CONFIG_PATH} <<EOF
+providers:
+  - name: "cluster-api"
+    url: ${CAPI_RELEASE_URL}
+    type: "CoreProvider"
+EOF
+
+# parameters that must be substituted in CAPI manifest
+export CAPI_DIAGNOSTICS_ADDRESS=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}
+export CAPI_INSECURE_DIAGNOSTICS=${CAPI_INSECURE_DIAGNOSTICS:=false}
+export EXP_MACHINE_POOL=${EXP_MACHINE_POOL:=true}
+export EXP_CLUSTER_RESOURCE_SET=${EXP_CLUSTER_RESOURCE_SET:=true}
+export CLUSTER_TOPOLOGY=${CLUSTER_TOPOLOGY:=true}
+export EXP_RUNTIME_SDK=${EXP_RUNTIME_SDK:=false}
+export EXP_MACHINE_SET_PREFLIGHT_CHECKS=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=true}
+export EXP_MACHINE_WAITFORVOLUMEDETACH_CONSIDER_VOLUMEATTACHMENTS=${EXP_MACHINE_WAITFORVOLUMEDETACH_CONSIDER_VOLUMEATTACHMENTS:=true}
+export EXP_PRIORITY_QUEUE=${EXP_PRIORITY_QUEUE:=false}
+
+# install clusterctl from source
+echo "Installing clusterctl from ${CLUSTERCTL_DOWNLOAD_URL}"
+curl -L ${CLUSTERCTL_DOWNLOAD_URL} -o clusterctl
+sudo install -o root -g root -m 0755 clusterctl /usr/local/bin/clusterctl
+
+# first set the conditional for this template
+cat <<EOF >${OUTPUT_DIR}/core-provider-airgapped.yaml
+{{- if and (index .Values "cluster-api-operator" "cluster-api" "enabled") (index .Values "rancherTurtles" "airGapped") }}
+EOF
+
+# use `clusterctl` to generate the body of the core CAPI template
+clusterctl generate provider --config ${CLUSTERCTL_CONFIG_PATH} --core cluster-api >>${OUTPUT_DIR}/core-provider-airgapped.yaml
+
+cat <<EOF >>${OUTPUT_DIR}/core-provider-airgapped.yaml
+{{- end }}
+EOF
+
+# embed this in Turtles chart
+mv ${OUTPUT_DIR}/core-provider-airgapped.yaml ./charts/rancher-turtles/templates/core-provider-airgapped.yaml
+
+# commit changes
+git add charts/rancher-turtles
+git commit -m "$COMMIT_MSG"

--- a/.github/workflows/fetch-core-capi-airgapped.yml
+++ b/.github/workflows/fetch-core-capi-airgapped.yml
@@ -1,0 +1,62 @@
+name: Fetch core CAPI components manifest and embed in Turtles chart for air-gapped installations.
+on:
+  # TODO: this is just for debugging
+  push:
+    branches: [ "feat-fetch-core-capi*" ]
+  workflow_dispatch:
+
+env:
+  TURTLES_REF: "${{ github.ref_name }}"
+  GH_TOKEN: "${{ secrets.GH_TOKEN }}"
+
+jobs:
+  create-core-capi-turtles-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for vault
+      id-token: write
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          ref: "${{ env.TURTLES_REF }}"
+          token: ${{ env.GH_TOKEN }}
+          # Allow making git push request later on
+          persist-credentials: true
+
+      - name: Configure the committer
+        run: |
+          user_id=$(gh api "/users/$APP_USER" --jq .id)
+          git config --global user.name "$APP_USER"
+          git config --global user.email "${user_id}+${APP_USER}@users.noreply.github.com"
+        env:
+          GH_TOKEN: "${{ env.GH_TOKEN }}"
+          APP_USER: "${{ github.actor }}"
+
+      - name: Install dependencies
+        run: |
+          sudo snap install jq curl
+
+      - name: Run script to fetch components manifest
+        run: |
+          #CAPI_VERSION=$(curl -s "https://api.github.com/repos/rancher-sandbox/cluster-api/releases/latest" | jq -r '.tag_name')
+          #echo $CAPI_VERSION
+          CAPI_VERSION=latest
+          echo "CAPI_VERSION=${CAPI_VERSION}" >> $GITHUB_ENV
+          BRANCH="fetch-core-capi-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+          git checkout -b "$BRANCH" "$TURTLES_REF"
+          CAPI_VERSION=$CAPI_VERSION ./.github/scripts/fetch-core-capi.sh
+
+      - name: Push and create pull request
+        env:
+          GH_TOKEN: "${{ env.GH_TOKEN }}"
+        run: |
+          git push origin "$BRANCH"
+          body="This PR fetches core CAPI $CAPI_VERSION components manifest from release and embeds the template in the Turtles chart for a simplified air-gapped installation."
+
+          gh pr create \
+            --title "Embed core CAPI provider $CAPI_VERSION components manifest in Turtles chart" \
+            --body "$body" \
+            --head "${{ github.repository_owner }}:$BRANCH" \
+            --base "$TURTLES_REF"

--- a/charts/rancher-turtles/templates/core-provider-airgapped.yaml
+++ b/charts/rancher-turtles/templates/core-provider-airgapped.yaml
@@ -1,0 +1,2 @@
+{{- if and (index .Values "cluster-api-operator" "cluster-api" "enabled") (index .Values "rancherTurtles" "airGapped") }}
+{{- end }}


### PR DESCRIPTION
This PR fetches core CAPI latest components manifest from release and embeds the template in the Turtles chart for a simplified air-gapped installation.