### PR TITLE
chore: embed core CAPI provider v1.10.5 manifest in chart

### DIFF
--- a/charts/rancher-turtles/templates/core-provider-airgapped.yaml
+++ b/charts/rancher-turtles/templates/core-provider-airgapped.yaml
@@ -1,0 +1,15860 @@
+{{- if and (index .Values "cluster-api-operator" "cluster-api" "enabled") (index .Values "rancherTurtles" "airGapped") }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+    control-plane: controller-manager
+  name: capi-system
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-selfsigned-issuer
+  namespace: capi-system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-serving-cert
+  namespace: capi-system
+spec:
+  dnsNames:
+  - capi-webhook-service.capi-system.svc
+  - capi-webhook-service.capi-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: capi-selfsigned-issuer
+  secretName: capi-webhook-service-cert
+  subject:
+    organizations:
+    - k8s-sig-cluster-lifecycle
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.17.2
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: clusterclasses.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ClusterClass
+    listKind: ClusterClassList
+    plural: clusterclasses
+    shortNames:
+    - cc
+    singular: clusterclass
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterClass
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterClass is a template which can be used to create managed topologies.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of ClusterClass.
+            properties:
+              controlPlane:
+                description: |-
+                  controlPlane is a reference to a local struct that holds the details
+                  for provisioning the Control Plane for the Cluster.
+                properties:
+                  machineInfrastructure:
+                    description: |-
+                      machineInfrastructure defines the metadata and infrastructure information
+                      for control plane machines.
+
+                      This field is supported if and only if the control plane provider template
+                      referenced above is Machine based and supports setting replicas.
+                    properties:
+                      ref:
+                        description: |-
+                          ref is a required reference to a custom resource
+                          offered by a provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - ref
+                    type: object
+                  metadata:
+                    description: |-
+                      metadata is the metadata applied to the machines of the ControlPlane.
+                      At runtime this metadata is merged with the corresponding metadata from the topology.
+
+                      This field is supported if and only if the control plane provider template
+                      referenced is Machine based.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  ref:
+                    description: |-
+                      ref is a required reference to a custom resource
+                      offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - ref
+                type: object
+              infrastructure:
+                description: |-
+                  infrastructure is a reference to a provider-specific template that holds
+                  the details for provisioning infrastructure specific cluster
+                  for the underlying provider.
+                  The underlying provider is responsible for the implementation
+                  of the template to an infrastructure cluster.
+                properties:
+                  ref:
+                    description: |-
+                      ref is a required reference to a custom resource
+                      offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - ref
+                type: object
+              workers:
+                description: |-
+                  workers describes the worker nodes for the cluster.
+                  It is a collection of node types which can be used to create
+                  the worker nodes of the cluster.
+                properties:
+                  machineDeployments:
+                    description: |-
+                      machineDeployments is a list of machine deployment classes that can be used to create
+                      a set of worker nodes.
+                    items:
+                      description: |-
+                        MachineDeploymentClass serves as a template to define a set of worker nodes of the cluster
+                        provisioned using the `ClusterClass`.
+                      properties:
+                        class:
+                          description: |-
+                            class denotes a type of worker node present in the cluster,
+                            this name MUST be unique within a ClusterClass and can be referenced
+                            in the Cluster to create a managed MachineDeployment.
+                          type: string
+                        template:
+                          description: |-
+                            template is a local struct containing a collection of templates for creation of
+                            MachineDeployment objects representing a set of worker nodes.
+                          properties:
+                            bootstrap:
+                              description: |-
+                                bootstrap contains the bootstrap template reference to be used
+                                for the creation of worker Machines.
+                              properties:
+                                ref:
+                                  description: |-
+                                    ref is a required reference to a custom resource
+                                    offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            infrastructure:
+                              description: |-
+                                infrastructure contains the infrastructure template reference to be used
+                                for the creation of worker Machines.
+                              properties:
+                                ref:
+                                  description: |-
+                                    ref is a required reference to a custom resource
+                                    offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            metadata:
+                              description: |-
+                                metadata is the metadata applied to the machines of the MachineDeployment.
+                                At runtime this metadata is merged with the corresponding metadata from the topology.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    annotations is an unstructured key value map stored with a resource that may be
+                                    set by external tools to store and retrieve arbitrary metadata. They are not
+                                    queryable and should be preserved when modifying objects.
+                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    labels is a map of string keys and values that can be used to organize and categorize
+                                    (scope and select) objects. May match selectors of replication controllers
+                                    and services.
+                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                  type: object
+                              type: object
+                          required:
+                          - bootstrap
+                          - infrastructure
+                          type: object
+                      required:
+                      - class
+                      - template
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterClass
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ClusterClass is a template which can be used to create managed
+          topologies.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of ClusterClass.
+            properties:
+              availabilityGates:
+                description: |-
+                  availabilityGates specifies additional conditions to include when evaluating Cluster Available condition.
+
+                  NOTE: this field is considered only for computing v1beta2 conditions.
+                  NOTE: If a Cluster is using this ClusterClass, and this Cluster defines a custom list of availabilityGates,
+                  such list overrides availabilityGates defined in this field.
+                items:
+                  description: ClusterAvailabilityGate contains the type of a Cluster
+                    condition to be used as availability gate.
+                  properties:
+                    conditionType:
+                      description: |-
+                        conditionType refers to a condition with matching type in the Cluster's condition list.
+                        If the conditions doesn't exist, it will be treated as unknown.
+                        Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as availability gates.
+                      maxLength: 316
+                      minLength: 1
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                    polarity:
+                      description: |-
+                        polarity of the conditionType specified in this availabilityGate.
+                        Valid values are Positive, Negative and omitted.
+                        When omitted, the default behaviour will be Positive.
+                        A positive polarity means that the condition should report a true status under normal conditions.
+                        A negative polarity means that the condition should report a false status under normal conditions.
+                      enum:
+                      - Positive
+                      - Negative
+                      type: string
+                  required:
+                  - conditionType
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - conditionType
+                x-kubernetes-list-type: map
+              controlPlane:
+                description: |-
+                  controlPlane is a reference to a local struct that holds the details
+                  for provisioning the Control Plane for the Cluster.
+                properties:
+                  machineHealthCheck:
+                    description: |-
+                      machineHealthCheck defines a MachineHealthCheck for this ControlPlaneClass.
+                      This field is supported if and only if the ControlPlane provider template
+                      referenced above is Machine based and supports setting replicas.
+                    properties:
+                      maxUnhealthy:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                          Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
+                          "selector" are not healthy.
+                        x-kubernetes-int-or-string: true
+                      nodeStartupTimeout:
+                        description: |-
+                          nodeStartupTimeout allows to set the maximum time for MachineHealthCheck
+                          to consider a Machine unhealthy if a corresponding Node isn't associated
+                          through a `Spec.ProviderID` field.
+
+                          The duration set in this field is compared to the greatest of:
+                          - Cluster's infrastructure ready condition timestamp (if and when available)
+                          - Control Plane's initialized condition timestamp (if and when available)
+                          - Machine's infrastructure ready condition timestamp (if and when available)
+                          - Machine's metadata creation timestamp
+
+                          Defaults to 10 minutes.
+                          If you wish to disable this feature, set the value explicitly to 0.
+                        type: string
+                      remediationTemplate:
+                        description: |-
+                          remediationTemplate is a reference to a remediation template
+                          provided by an infrastructure provider.
+
+                          This field is completely optional, when filled, the MachineHealthCheck controller
+                          creates a new object from the template referenced and hands off remediation of the machine to
+                          a controller that lives outside of Cluster API.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      unhealthyConditions:
+                        description: |-
+                          unhealthyConditions contains a list of the conditions that determine
+                          whether a node is considered unhealthy. The conditions are combined in a
+                          logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                        items:
+                          description: |-
+                            UnhealthyCondition represents a Node condition type and value with a timeout
+                            specified as a duration.  When the named condition has been in the given
+                            status for at least the timeout value, a node is considered unhealthy.
+                          properties:
+                            status:
+                              description: status of the condition, one of True, False,
+                                Unknown.
+                              minLength: 1
+                              type: string
+                            timeout:
+                              description: |-
+                                timeout is the duration that a node must be in a given status for,
+                                after which the node is considered unhealthy.
+                                For example, with a value of "1h", the node must match the status
+                                for at least 1 hour before being considered unhealthy.
+                              type: string
+                            type:
+                              description: type of Node condition
+                              minLength: 1
+                              type: string
+                          required:
+                          - status
+                          - timeout
+                          - type
+                          type: object
+                        maxItems: 100
+                        type: array
+                      unhealthyRange:
+                        description: |-
+                          unhealthyRange specifies the range of unhealthy machines allowed.
+                          Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
+                          is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
+                          Eg. "[3-5]" - This means that remediation will be allowed only when:
+                          (a) there are at least 3 unhealthy machines (and)
+                          (b) there are at most 5 unhealthy machines
+                        maxLength: 32
+                        minLength: 1
+                        pattern: ^\[[0-9]+-[0-9]+\]$
+                        type: string
+                    type: object
+                  machineInfrastructure:
+                    description: |-
+                      machineInfrastructure defines the metadata and infrastructure information
+                      for control plane machines.
+
+                      This field is supported if and only if the control plane provider template
+                      referenced above is Machine based and supports setting replicas.
+                    properties:
+                      ref:
+                        description: |-
+                          ref is a required reference to a custom resource
+                          offered by a provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - ref
+                    type: object
+                  metadata:
+                    description: |-
+                      metadata is the metadata applied to the ControlPlane and the Machines of the ControlPlane
+                      if the ControlPlaneTemplate referenced is machine based. If not, it is applied only to the
+                      ControlPlane.
+                      At runtime this metadata is merged with the corresponding metadata from the topology.
+
+                      This field is supported if and only if the control plane provider template
+                      referenced is Machine based.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  namingStrategy:
+                    description: namingStrategy allows changing the naming pattern
+                      used when creating the control plane provider object.
+                    properties:
+                      template:
+                        description: |-
+                          template defines the template to use for generating the name of the ControlPlane object.
+                          If not defined, it will fallback to `{{ .cluster.name }}-{{ .random }}`.
+                          If the templated string exceeds 63 characters, it will be trimmed to 58 characters and will
+                          get concatenated with a random suffix of length 5.
+                          The templating mechanism provides the following arguments:
+                          * `.cluster.name`: The name of the cluster object.
+                          * `.random`: A random alphanumeric string, without vowels, of length 5.
+                        maxLength: 1024
+                        minLength: 1
+                        type: string
+                    type: object
+                  nodeDeletionTimeout:
+                    description: |-
+                      nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                      hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                      Defaults to 10 seconds.
+                      NOTE: This value can be overridden while defining a Cluster.Topology.
+                    type: string
+                  nodeDrainTimeout:
+                    description: |-
+                      nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                      The default value is 0, meaning that the node can be drained without any time limitations.
+                      NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                      NOTE: This value can be overridden while defining a Cluster.Topology.
+                    type: string
+                  nodeVolumeDetachTimeout:
+                    description: |-
+                      nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                      to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                      NOTE: This value can be overridden while defining a Cluster.Topology.
+                    type: string
+                  readinessGates:
+                    description: |-
+                      readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                      This field can be used e.g. to instruct the machine controller to include in the computation for Machine's ready
+                      computation a condition, managed by an external controllers, reporting the status of special software/hardware installed on the Machine.
+
+                      NOTE: This field is considered only for computing v1beta2 conditions.
+                      NOTE: If a Cluster defines a custom list of readinessGates for the control plane,
+                      such list overrides readinessGates defined in this field.
+                      NOTE: Specific control plane provider implementations might automatically extend the list of readinessGates;
+                      e.g. the kubeadm control provider adds ReadinessGates for the APIServerPodHealthy, SchedulerPodHealthy conditions, etc.
+                    items:
+                      description: MachineReadinessGate contains the type of a Machine
+                        condition to be used as a readiness gate.
+                      properties:
+                        conditionType:
+                          description: |-
+                            conditionType refers to a condition with matching type in the Machine's condition list.
+                            If the conditions doesn't exist, it will be treated as unknown.
+                            Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                          maxLength: 316
+                          minLength: 1
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                        polarity:
+                          description: |-
+                            polarity of the conditionType specified in this readinessGate.
+                            Valid values are Positive, Negative and omitted.
+                            When omitted, the default behaviour will be Positive.
+                            A positive polarity means that the condition should report a true status under normal conditions.
+                            A negative polarity means that the condition should report a false status under normal conditions.
+                          enum:
+                          - Positive
+                          - Negative
+                          type: string
+                      required:
+                      - conditionType
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - conditionType
+                    x-kubernetes-list-type: map
+                  ref:
+                    description: |-
+                      ref is a required reference to a custom resource
+                      offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - ref
+                type: object
+              infrastructure:
+                description: |-
+                  infrastructure is a reference to a provider-specific template that holds
+                  the details for provisioning infrastructure specific cluster
+                  for the underlying provider.
+                  The underlying provider is responsible for the implementation
+                  of the template to an infrastructure cluster.
+                properties:
+                  ref:
+                    description: |-
+                      ref is a required reference to a custom resource
+                      offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - ref
+                type: object
+              infrastructureNamingStrategy:
+                description: infrastructureNamingStrategy allows changing the naming
+                  pattern used when creating the infrastructure object.
+                properties:
+                  template:
+                    description: |-
+                      template defines the template to use for generating the name of the Infrastructure object.
+                      If not defined, it will fallback to `{{ .cluster.name }}-{{ .random }}`.
+                      If the templated string exceeds 63 characters, it will be trimmed to 58 characters and will
+                      get concatenated with a random suffix of length 5.
+                      The templating mechanism provides the following arguments:
+                      * `.cluster.name`: The name of the cluster object.
+                      * `.random`: A random alphanumeric string, without vowels, of length 5.
+                    maxLength: 1024
+                    minLength: 1
+                    type: string
+                type: object
+              patches:
+                description: |-
+                  patches defines the patches which are applied to customize
+                  referenced templates of a ClusterClass.
+                  Note: Patches will be applied in the order of the array.
+                items:
+                  description: ClusterClassPatch defines a patch which is applied
+                    to customize the referenced templates.
+                  properties:
+                    definitions:
+                      description: |-
+                        definitions define inline patches.
+                        Note: Patches will be applied in the order of the array.
+                        Note: Exactly one of Definitions or External must be set.
+                      items:
+                        description: PatchDefinition defines a patch which is applied
+                          to customize the referenced templates.
+                        properties:
+                          jsonPatches:
+                            description: |-
+                              jsonPatches defines the patches which should be applied on the templates
+                              matching the selector.
+                              Note: Patches will be applied in the order of the array.
+                            items:
+                              description: JSONPatch defines a JSON patch.
+                              properties:
+                                op:
+                                  description: |-
+                                    op defines the operation of the patch.
+                                    Note: Only `add`, `replace` and `remove` are supported.
+                                  enum:
+                                  - add
+                                  - replace
+                                  - remove
+                                  type: string
+                                path:
+                                  description: |-
+                                    path defines the path of the patch.
+                                    Note: Only the spec of a template can be patched, thus the path has to start with /spec/.
+                                    Note: For now the only allowed array modifications are `append` and `prepend`, i.e.:
+                                    * for op: `add`: only index 0 (prepend) and - (append) are allowed
+                                    * for op: `replace` or `remove`: no indexes are allowed
+                                  maxLength: 512
+                                  minLength: 1
+                                  type: string
+                                value:
+                                  description: |-
+                                    value defines the value of the patch.
+                                    Note: Either Value or ValueFrom is required for add and replace
+                                    operations. Only one of them is allowed to be set at the same time.
+                                    Note: We have to use apiextensionsv1.JSON instead of our JSON type,
+                                    because controller-tools has a hard-coded schema for apiextensionsv1.JSON
+                                    which cannot be produced by another type (unset type field).
+                                    Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111
+                                  x-kubernetes-preserve-unknown-fields: true
+                                valueFrom:
+                                  description: |-
+                                    valueFrom defines the value of the patch.
+                                    Note: Either Value or ValueFrom is required for add and replace
+                                    operations. Only one of them is allowed to be set at the same time.
+                                  properties:
+                                    template:
+                                      description: |-
+                                        template is the Go template to be used to calculate the value.
+                                        A template can reference variables defined in .spec.variables and builtin variables.
+                                        Note: The template must evaluate to a valid YAML or JSON value.
+                                      maxLength: 10240
+                                      minLength: 1
+                                      type: string
+                                    variable:
+                                      description: |-
+                                        variable is the variable to be used as value.
+                                        Variable can be one of the variables defined in .spec.variables or a builtin variable.
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                  type: object
+                              required:
+                              - op
+                              - path
+                              type: object
+                            maxItems: 100
+                            type: array
+                          selector:
+                            description: selector defines on which templates the patch
+                              should be applied.
+                            properties:
+                              apiVersion:
+                                description: apiVersion filters templates by apiVersion.
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                              kind:
+                                description: kind filters templates by kind.
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                              matchResources:
+                                description: matchResources selects templates based
+                                  on where they are referenced.
+                                properties:
+                                  controlPlane:
+                                    description: |-
+                                      controlPlane selects templates referenced in .spec.ControlPlane.
+                                      Note: this will match the controlPlane and also the controlPlane
+                                      machineInfrastructure (depending on the kind and apiVersion).
+                                    type: boolean
+                                  infrastructureCluster:
+                                    description: infrastructureCluster selects templates
+                                      referenced in .spec.infrastructure.
+                                    type: boolean
+                                  machineDeploymentClass:
+                                    description: |-
+                                      machineDeploymentClass selects templates referenced in specific MachineDeploymentClasses in
+                                      .spec.workers.machineDeployments.
+                                    properties:
+                                      names:
+                                        description: names selects templates by class
+                                          names.
+                                        items:
+                                          maxLength: 256
+                                          minLength: 1
+                                          type: string
+                                        maxItems: 100
+                                        type: array
+                                    type: object
+                                  machinePoolClass:
+                                    description: |-
+                                      machinePoolClass selects templates referenced in specific MachinePoolClasses in
+                                      .spec.workers.machinePools.
+                                    properties:
+                                      names:
+                                        description: names selects templates by class
+                                          names.
+                                        items:
+                                          maxLength: 256
+                                          minLength: 1
+                                          type: string
+                                        maxItems: 100
+                                        type: array
+                                    type: object
+                                type: object
+                            required:
+                            - apiVersion
+                            - kind
+                            - matchResources
+                            type: object
+                        required:
+                        - jsonPatches
+                        - selector
+                        type: object
+                      maxItems: 100
+                      type: array
+                    description:
+                      description: description is a human-readable description of
+                        this patch.
+                      maxLength: 1024
+                      minLength: 1
+                      type: string
+                    enabledIf:
+                      description: |-
+                        enabledIf is a Go template to be used to calculate if a patch should be enabled.
+                        It can reference variables defined in .spec.variables and builtin variables.
+                        The patch will be enabled if the template evaluates to `true`, otherwise it will
+                        be disabled.
+                        If EnabledIf is not set, the patch will be enabled per default.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    external:
+                      description: |-
+                        external defines an external patch.
+                        Note: Exactly one of Definitions or External must be set.
+                      properties:
+                        discoverVariablesExtension:
+                          description: discoverVariablesExtension references an extension
+                            which is called to discover variables.
+                          maxLength: 512
+                          minLength: 1
+                          type: string
+                        generateExtension:
+                          description: generateExtension references an extension which
+                            is called to generate patches.
+                          maxLength: 512
+                          minLength: 1
+                          type: string
+                        settings:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            settings defines key value pairs to be passed to the extensions.
+                            Values defined here take precedence over the values defined in the
+                            corresponding ExtensionConfig.
+                          type: object
+                        validateExtension:
+                          description: validateExtension references an extension which
+                            is called to validate the topology.
+                          maxLength: 512
+                          minLength: 1
+                          type: string
+                      type: object
+                    name:
+                      description: name of the patch.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 1000
+                type: array
+              variables:
+                description: |-
+                  variables defines the variables which can be configured
+                  in the Cluster topology and are then used in patches.
+                items:
+                  description: |-
+                    ClusterClassVariable defines a variable which can
+                    be configured in the Cluster topology and used in patches.
+                  properties:
+                    metadata:
+                      description: |-
+                        metadata is the metadata of a variable.
+                        It can be used to add additional data for higher level tools to
+                        a ClusterClassVariable.
+
+                        Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please use XMetadata in JSONSchemaProps instead.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            annotations is an unstructured key value map that can be used to store and
+                            retrieve arbitrary metadata.
+                            They are not queryable.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            labels is a map of string keys and values that can be used to organize and categorize
+                            (scope and select) variables.
+                          type: object
+                      type: object
+                    name:
+                      description: name of the variable.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    required:
+                      description: |-
+                        required specifies if the variable is required.
+                        Note: this applies to the variable as a whole and thus the
+                        top-level object defined in the schema. If nested fields are
+                        required, this will be specified inside the schema.
+                      type: boolean
+                    schema:
+                      description: schema defines the schema of the variable.
+                      properties:
+                        openAPIV3Schema:
+                          description: |-
+                            openAPIV3Schema defines the schema of a variable via OpenAPI v3
+                            schema. The schema is a subset of the schema used in
+                            Kubernetes CRDs.
+                          properties:
+                            additionalProperties:
+                              description: |-
+                                additionalProperties specifies the schema of values in a map (keys are always strings).
+                                NOTE: Can only be set if type is object.
+                                NOTE: AdditionalProperties is mutually exclusive with Properties.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            allOf:
+                              description: |-
+                                allOf specifies that the variable must validate against all of the subschemas in the array.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            anyOf:
+                              description: |-
+                                anyOf specifies that the variable must validate against one or more of the subschemas in the array.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            default:
+                              description: |-
+                                default is the default value of the variable.
+                                NOTE: Can be set for all types.
+                              x-kubernetes-preserve-unknown-fields: true
+                            description:
+                              description: description is a human-readable description
+                                of this variable.
+                              maxLength: 4096
+                              minLength: 1
+                              type: string
+                            enum:
+                              description: |-
+                                enum is the list of valid values of the variable.
+                                NOTE: Can be set for all types.
+                              items:
+                                x-kubernetes-preserve-unknown-fields: true
+                              maxItems: 100
+                              type: array
+                            example:
+                              description: example is an example for this variable.
+                              x-kubernetes-preserve-unknown-fields: true
+                            exclusiveMaximum:
+                              description: |-
+                                exclusiveMaximum specifies if the Maximum is exclusive.
+                                NOTE: Can only be set if type is integer or number.
+                              type: boolean
+                            exclusiveMinimum:
+                              description: |-
+                                exclusiveMinimum specifies if the Minimum is exclusive.
+                                NOTE: Can only be set if type is integer or number.
+                              type: boolean
+                            format:
+                              description: |-
+                                format is an OpenAPI v3 format string. Unknown formats are ignored.
+                                For a list of supported formats please see: (of the k8s.io/apiextensions-apiserver version we're currently using)
+                                https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apiserver/validation/formats.go
+                                NOTE: Can only be set if type is string.
+                              maxLength: 32
+                              minLength: 1
+                              type: string
+                            items:
+                              description: |-
+                                items specifies fields of an array.
+                                NOTE: Can only be set if type is array.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            maxItems:
+                              description: |-
+                                maxItems is the max length of an array variable.
+                                NOTE: Can only be set if type is array.
+                              format: int64
+                              type: integer
+                            maxLength:
+                              description: |-
+                                maxLength is the max length of a string variable.
+                                NOTE: Can only be set if type is string.
+                              format: int64
+                              type: integer
+                            maxProperties:
+                              description: |-
+                                maxProperties is the maximum amount of entries in a map or properties in an object.
+                                NOTE: Can only be set if type is object.
+                              format: int64
+                              type: integer
+                            maximum:
+                              description: |-
+                                maximum is the maximum of an integer or number variable.
+                                If ExclusiveMaximum is false, the variable is valid if it is lower than, or equal to, the value of Maximum.
+                                If ExclusiveMaximum is true, the variable is valid if it is strictly lower than the value of Maximum.
+                                NOTE: Can only be set if type is integer or number.
+                              format: int64
+                              type: integer
+                            minItems:
+                              description: |-
+                                minItems is the min length of an array variable.
+                                NOTE: Can only be set if type is array.
+                              format: int64
+                              type: integer
+                            minLength:
+                              description: |-
+                                minLength is the min length of a string variable.
+                                NOTE: Can only be set if type is string.
+                              format: int64
+                              type: integer
+                            minProperties:
+                              description: |-
+                                minProperties is the minimum amount of entries in a map or properties in an object.
+                                NOTE: Can only be set if type is object.
+                              format: int64
+                              type: integer
+                            minimum:
+                              description: |-
+                                minimum is the minimum of an integer or number variable.
+                                If ExclusiveMinimum is false, the variable is valid if it is greater than, or equal to, the value of Minimum.
+                                If ExclusiveMinimum is true, the variable is valid if it is strictly greater than the value of Minimum.
+                                NOTE: Can only be set if type is integer or number.
+                              format: int64
+                              type: integer
+                            not:
+                              description: |-
+                                not specifies that the variable must not validate against the subschema.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            oneOf:
+                              description: |-
+                                oneOf specifies that the variable must validate against exactly one of the subschemas in the array.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            pattern:
+                              description: |-
+                                pattern is the regex which a string variable must match.
+                                NOTE: Can only be set if type is string.
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            properties:
+                              description: |-
+                                properties specifies fields of an object.
+                                NOTE: Can only be set if type is object.
+                                NOTE: Properties is mutually exclusive with AdditionalProperties.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            required:
+                              description: |-
+                                required specifies which fields of an object are required.
+                                NOTE: Can only be set if type is object.
+                              items:
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                              maxItems: 1000
+                              type: array
+                            type:
+                              description: |-
+                                type is the type of the variable.
+                                Valid values are: object, array, string, integer, number or boolean.
+                              enum:
+                              - object
+                              - array
+                              - string
+                              - integer
+                              - number
+                              - boolean
+                              type: string
+                            uniqueItems:
+                              description: |-
+                                uniqueItems specifies if items in an array must be unique.
+                                NOTE: Can only be set if type is array.
+                              type: boolean
+                            x-kubernetes-int-or-string:
+                              description: |-
+                                x-kubernetes-int-or-string specifies that this value is
+                                either an integer or a string. If this is true, an empty
+                                type is allowed and type as child of anyOf is permitted
+                                if following one of the following patterns:
+
+                                1) anyOf:
+                                   - type: integer
+                                   - type: string
+                                2) allOf:
+                                   - anyOf:
+                                     - type: integer
+                                     - type: string
+                                   - ... zero or more
+                              type: boolean
+                            x-kubernetes-preserve-unknown-fields:
+                              description: |-
+                                x-kubernetes-preserve-unknown-fields allows setting fields in a variable object
+                                which are not defined in the variable schema. This affects fields recursively,
+                                except if nested properties or additionalProperties are specified in the schema.
+                              type: boolean
+                            x-kubernetes-validations:
+                              description: x-kubernetes-validations describes a list
+                                of validation rules written in the CEL expression
+                                language.
+                              items:
+                                description: ValidationRule describes a validation
+                                  rule written in the CEL expression language.
+                                properties:
+                                  fieldPath:
+                                    description: |-
+                                      fieldPath represents the field path returned when the validation fails.
+                                      It must be a relative JSON path (i.e. with array notation) scoped to the location of this x-kubernetes-validations extension in the schema and refer to an existing field.
+                                      e.g. when validation checks if a specific attribute `foo` under a map `testMap`, the fieldPath could be set to `.testMap.foo`
+                                      If the validation checks two lists must have unique attributes, the fieldPath could be set to either of the list: e.g. `.testList`
+                                      It does not support list numeric index.
+                                      It supports child operation to refer to an existing field currently. Refer to [JSONPath support in Kubernetes](https://kubernetes.io/docs/reference/kubectl/jsonpath/) for more info.
+                                      Numeric index of array is not supported.
+                                      For field name which contains special characters, use `['specialName']` to refer the field name.
+                                      e.g. for attribute `foo.34$` appears in a list `testList`, the fieldPath could be set to `.testList['foo.34$']`
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                  message:
+                                    description: |-
+                                      message represents the message displayed when validation fails. The message is required if the Rule contains
+                                      line breaks. The message must not contain line breaks.
+                                      If unset, the message is "failed rule: {Rule}".
+                                      e.g. "must be a URL with the host matching spec.host"
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                  messageExpression:
+                                    description: |-
+                                      messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails.
+                                      Since messageExpression is used as a failure message, it must evaluate to a string.
+                                      If both message and messageExpression are present on a rule, then messageExpression will be used if validation
+                                      fails. If messageExpression results in a runtime error, the validation failure message is produced
+                                      as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string
+                                      that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset.
+                                      messageExpression has access to all the same variables as the rule; the only difference is the return type.
+                                      Example:
+                                      "x must be less than max ("+string(self.max)+")"
+                                    maxLength: 1024
+                                    minLength: 1
+                                    type: string
+                                  reason:
+                                    default: FieldValueInvalid
+                                    description: |-
+                                      reason provides a machine-readable validation failure reason that is returned to the caller when a request fails this validation rule.
+                                      The currently supported reasons are: "FieldValueInvalid", "FieldValueForbidden", "FieldValueRequired", "FieldValueDuplicate".
+                                      If not set, default to use "FieldValueInvalid".
+                                      All future added reasons must be accepted by clients when reading this value and unknown reasons should be treated as FieldValueInvalid.
+                                    enum:
+                                    - FieldValueInvalid
+                                    - FieldValueForbidden
+                                    - FieldValueRequired
+                                    - FieldValueDuplicate
+                                    type: string
+                                  rule:
+                                    description: "rule represents the expression which
+                                      will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nThe
+                                      Rule is scoped to the location of the x-kubernetes-validations
+                                      extension in the schema.\nThe `self` variable
+                                      in the CEL expression is bound to the scoped
+                                      value.\nIf the Rule is scoped to an object with
+                                      properties, the accessible properties of the
+                                      object are field selectable\nvia `self.field`
+                                      and field presence can be checked via `has(self.field)`.\nIf
+                                      the Rule is scoped to an object with additionalProperties
+                                      (i.e. a map) the value of the map\nare accessible
+                                      via `self[mapKey]`, map containment can be checked
+                                      via `mapKey in self` and all entries of the
+                                      map\nare accessible via CEL macros and functions
+                                      such as `self.all(...)`.\nIf the Rule is scoped
+                                      to an array, the elements of the array are accessible
+                                      via `self[i]` and also by macros and\nfunctions.\nIf
+                                      the Rule is scoped to a scalar, `self` is bound
+                                      to the scalar value.\nExamples:\n- Rule scoped
+                                      to a map of objects: {\"rule\": \"self.components['Widget'].priority
+                                      < 10\"}\n- Rule scoped to a list of integers:
+                                      {\"rule\": \"self.values.all(value, value >=
+                                      0 && value < 100)\"}\n- Rule scoped to a string
+                                      value: {\"rule\": \"self.startsWith('kube')\"}\n\nUnknown
+                                      data preserved in custom resources via x-kubernetes-preserve-unknown-fields
+                                      is not accessible in CEL\nexpressions. This
+                                      includes:\n- Unknown field values that are preserved
+                                      by object schemas with x-kubernetes-preserve-unknown-fields.\n-
+                                      Object properties where the property schema
+                                      is of an \"unknown type\". An \"unknown type\"
+                                      is recursively defined as:\n  - A schema with
+                                      no type and x-kubernetes-preserve-unknown-fields
+                                      set to true\n  - An array where the items schema
+                                      is of an \"unknown type\"\n  - An object where
+                                      the additionalProperties schema is of an \"unknown
+                                      type\"\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*`
+                                      are accessible.\nAccessible property names are
+                                      escaped according to the following rules when
+                                      accessed in the expression:\n- '__' escapes
+                                      to '__underscores__'\n- '.' escapes to '__dot__'\n-
+                                      '-' escapes to '__dash__'\n- '/' escapes to
+                                      '__slash__'\n- Property names that exactly match
+                                      a CEL RESERVED keyword escape to '__{keyword}__'.
+                                      The keywords are:\n\t  \"true\", \"false\",
+                                      \"null\", \"in\", \"as\", \"break\", \"const\",
+                                      \"continue\", \"else\", \"for\", \"function\",
+                                      \"if\",\n\t  \"import\", \"let\", \"loop\",
+                                      \"package\", \"namespace\", \"return\".\nExamples:\n
+                                      \ - Rule accessing a property named \"namespace\":
+                                      {\"rule\": \"self.__namespace__ > 0\"}\n  -
+                                      Rule accessing a property named \"x-prop\":
+                                      {\"rule\": \"self.x__dash__prop > 0\"}\n  -
+                                      Rule accessing a property named \"redact__d\":
+                                      {\"rule\": \"self.redact__underscores__d > 0\"}\n\nIf
+                                      `rule` makes use of the `oldSelf` variable it
+                                      is implicitly a\n`transition rule`.\n\nBy default,
+                                      the `oldSelf` variable is the same type as `self`.\n\nTransition
+                                      rules by default are applied only on UPDATE
+                                      requests and are\nskipped if an old value could
+                                      not be found."
+                                    maxLength: 4096
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - rule
+                                type: object
+                              maxItems: 100
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - rule
+                              x-kubernetes-list-type: map
+                            x-metadata:
+                              description: |-
+                                x-metadata is the metadata of a variable or a nested field within a variable.
+                                It can be used to add additional data for higher level tools.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    annotations is an unstructured key value map that can be used to store and
+                                    retrieve arbitrary metadata.
+                                    They are not queryable.
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    labels is a map of string keys and values that can be used to organize and categorize
+                                    (scope and select) variables.
+                                  type: object
+                              type: object
+                          type: object
+                      required:
+                      - openAPIV3Schema
+                      type: object
+                  required:
+                  - name
+                  - required
+                  - schema
+                  type: object
+                maxItems: 1000
+                type: array
+              workers:
+                description: |-
+                  workers describes the worker nodes for the cluster.
+                  It is a collection of node types which can be used to create
+                  the worker nodes of the cluster.
+                properties:
+                  machineDeployments:
+                    description: |-
+                      machineDeployments is a list of machine deployment classes that can be used to create
+                      a set of worker nodes.
+                    items:
+                      description: |-
+                        MachineDeploymentClass serves as a template to define a set of worker nodes of the cluster
+                        provisioned using the `ClusterClass`.
+                      properties:
+                        class:
+                          description: |-
+                            class denotes a type of worker node present in the cluster,
+                            this name MUST be unique within a ClusterClass and can be referenced
+                            in the Cluster to create a managed MachineDeployment.
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        failureDomain:
+                          description: |-
+                            failureDomain is the failure domain the machines will be created in.
+                            Must match a key in the FailureDomains map stored on the cluster object.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        machineHealthCheck:
+                          description: machineHealthCheck defines a MachineHealthCheck
+                            for this MachineDeploymentClass.
+                          properties:
+                            maxUnhealthy:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                                Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
+                                "selector" are not healthy.
+                              x-kubernetes-int-or-string: true
+                            nodeStartupTimeout:
+                              description: |-
+                                nodeStartupTimeout allows to set the maximum time for MachineHealthCheck
+                                to consider a Machine unhealthy if a corresponding Node isn't associated
+                                through a `Spec.ProviderID` field.
+
+                                The duration set in this field is compared to the greatest of:
+                                - Cluster's infrastructure ready condition timestamp (if and when available)
+                                - Control Plane's initialized condition timestamp (if and when available)
+                                - Machine's infrastructure ready condition timestamp (if and when available)
+                                - Machine's metadata creation timestamp
+
+                                Defaults to 10 minutes.
+                                If you wish to disable this feature, set the value explicitly to 0.
+                              type: string
+                            remediationTemplate:
+                              description: |-
+                                remediationTemplate is a reference to a remediation template
+                                provided by an infrastructure provider.
+
+                                This field is completely optional, when filled, the MachineHealthCheck controller
+                                creates a new object from the template referenced and hands off remediation of the machine to
+                                a controller that lives outside of Cluster API.
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent.
+                                  type: string
+                                fieldPath:
+                                  description: |-
+                                    If referring to a piece of an object instead of an entire object, this string
+                                    should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                    For example, if the object reference is to a container within a pod, this would take on a value like:
+                                    "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                    the event) or if no container name is specified "spec.containers[2]" (container with
+                                    index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                    referencing a part of an object.
+                                  type: string
+                                kind:
+                                  description: |-
+                                    Kind of the referent.
+                                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                  type: string
+                                resourceVersion:
+                                  description: |-
+                                    Specific resourceVersion to which this reference is made, if any.
+                                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                  type: string
+                                uid:
+                                  description: |-
+                                    UID of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            unhealthyConditions:
+                              description: |-
+                                unhealthyConditions contains a list of the conditions that determine
+                                whether a node is considered unhealthy. The conditions are combined in a
+                                logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                              items:
+                                description: |-
+                                  UnhealthyCondition represents a Node condition type and value with a timeout
+                                  specified as a duration.  When the named condition has been in the given
+                                  status for at least the timeout value, a node is considered unhealthy.
+                                properties:
+                                  status:
+                                    description: status of the condition, one of True,
+                                      False, Unknown.
+                                    minLength: 1
+                                    type: string
+                                  timeout:
+                                    description: |-
+                                      timeout is the duration that a node must be in a given status for,
+                                      after which the node is considered unhealthy.
+                                      For example, with a value of "1h", the node must match the status
+                                      for at least 1 hour before being considered unhealthy.
+                                    type: string
+                                  type:
+                                    description: type of Node condition
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - status
+                                - timeout
+                                - type
+                                type: object
+                              maxItems: 100
+                              type: array
+                            unhealthyRange:
+                              description: |-
+                                unhealthyRange specifies the range of unhealthy machines allowed.
+                                Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
+                                is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
+                                Eg. "[3-5]" - This means that remediation will be allowed only when:
+                                (a) there are at least 3 unhealthy machines (and)
+                                (b) there are at most 5 unhealthy machines
+                              maxLength: 32
+                              minLength: 1
+                              pattern: ^\[[0-9]+-[0-9]+\]$
+                              type: string
+                          type: object
+                        minReadySeconds:
+                          description: |-
+                            minReadySeconds is the minimum number of seconds for which a newly created machine should
+                            be ready.
+                            Defaults to 0 (machine will be considered available as soon as it
+                            is ready)
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
+                          format: int32
+                          type: integer
+                        namingStrategy:
+                          description: namingStrategy allows changing the naming pattern
+                            used when creating the MachineDeployment.
+                          properties:
+                            template:
+                              description: |-
+                                template defines the template to use for generating the name of the MachineDeployment object.
+                                If not defined, it will fallback to `{{ .cluster.name }}-{{ .machineDeployment.topologyName }}-{{ .random }}`.
+                                If the templated string exceeds 63 characters, it will be trimmed to 58 characters and will
+                                get concatenated with a random suffix of length 5.
+                                The templating mechanism provides the following arguments:
+                                * `.cluster.name`: The name of the cluster object.
+                                * `.random`: A random alphanumeric string, without vowels, of length 5.
+                                * `.machineDeployment.topologyName`: The name of the MachineDeployment topology (Cluster.spec.topology.workers.machineDeployments[].name).
+                              maxLength: 1024
+                              minLength: 1
+                              type: string
+                          type: object
+                        nodeDeletionTimeout:
+                          description: |-
+                            nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                            hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                            Defaults to 10 seconds.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
+                          type: string
+                        nodeDrainTimeout:
+                          description: |-
+                            nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                            The default value is 0, meaning that the node can be drained without any time limitations.
+                            NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
+                          type: string
+                        nodeVolumeDetachTimeout:
+                          description: |-
+                            nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                            to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
+                          type: string
+                        readinessGates:
+                          description: |-
+                            readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                            This field can be used e.g. to instruct the machine controller to include in the computation for Machine's ready
+                            computation a condition, managed by an external controllers, reporting the status of special software/hardware installed on the Machine.
+
+                            NOTE: This field is considered only for computing v1beta2 conditions.
+                            NOTE: If a Cluster defines a custom list of readinessGates for a MachineDeployment using this MachineDeploymentClass,
+                            such list overrides readinessGates defined in this field.
+                          items:
+                            description: MachineReadinessGate contains the type of
+                              a Machine condition to be used as a readiness gate.
+                            properties:
+                              conditionType:
+                                description: |-
+                                  conditionType refers to a condition with matching type in the Machine's condition list.
+                                  If the conditions doesn't exist, it will be treated as unknown.
+                                  Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                                maxLength: 316
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                              polarity:
+                                description: |-
+                                  polarity of the conditionType specified in this readinessGate.
+                                  Valid values are Positive, Negative and omitted.
+                                  When omitted, the default behaviour will be Positive.
+                                  A positive polarity means that the condition should report a true status under normal conditions.
+                                  A negative polarity means that the condition should report a false status under normal conditions.
+                                enum:
+                                - Positive
+                                - Negative
+                                type: string
+                            required:
+                            - conditionType
+                            type: object
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - conditionType
+                          x-kubernetes-list-type: map
+                        strategy:
+                          description: |-
+                            strategy is the deployment strategy to use to replace existing machines with
+                            new ones.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
+                          properties:
+                            remediation:
+                              description: |-
+                                remediation controls the strategy of remediating unhealthy machines
+                                and how remediating operations should occur during the lifecycle of the dependant MachineSets.
+                              properties:
+                                maxInFlight:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    maxInFlight determines how many in flight remediations should happen at the same time.
+
+                                    Remediation only happens on the MachineSet with the most current revision, while
+                                    older MachineSets (usually present during rollout operations) aren't allowed to remediate.
+
+                                    Note: In general (independent of remediations), unhealthy machines are always
+                                    prioritized during scale down operations over healthy ones.
+
+                                    MaxInFlight can be set to a fixed number or a percentage.
+                                    Example: when this is set to 20%, the MachineSet controller deletes at most 20% of
+                                    the desired replicas.
+
+                                    If not set, remediation is limited to all machines (bounded by replicas)
+                                    under the active MachineSet's management.
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            rollingUpdate:
+                              description: |-
+                                rollingUpdate is the rolling update config params. Present only if
+                                MachineDeploymentStrategyType = RollingUpdate.
+                              properties:
+                                deletePolicy:
+                                  description: |-
+                                    deletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling.
+                                    Valid values are "Random, "Newest", "Oldest"
+                                    When no value is supplied, the default DeletePolicy of MachineSet is used
+                                  enum:
+                                  - Random
+                                  - Newest
+                                  - Oldest
+                                  type: string
+                                maxSurge:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    maxSurge is the maximum number of machines that can be scheduled above the
+                                    desired number of machines.
+                                    Value can be an absolute number (ex: 5) or a percentage of
+                                    desired machines (ex: 10%).
+                                    This can not be 0 if MaxUnavailable is 0.
+                                    Absolute number is calculated from percentage by rounding up.
+                                    Defaults to 1.
+                                    Example: when this is set to 30%, the new MachineSet can be scaled
+                                    up immediately when the rolling update starts, such that the total
+                                    number of old and new machines do not exceed 130% of desired
+                                    machines. Once old machines have been killed, new MachineSet can
+                                    be scaled up further, ensuring that total number of machines running
+                                    at any time during the update is at most 130% of desired machines.
+                                  x-kubernetes-int-or-string: true
+                                maxUnavailable:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    maxUnavailable is the maximum number of machines that can be unavailable during the update.
+                                    Value can be an absolute number (ex: 5) or a percentage of desired
+                                    machines (ex: 10%).
+                                    Absolute number is calculated from percentage by rounding down.
+                                    This can not be 0 if MaxSurge is 0.
+                                    Defaults to 0.
+                                    Example: when this is set to 30%, the old MachineSet can be scaled
+                                    down to 70% of desired machines immediately when the rolling update
+                                    starts. Once new machines are ready, old MachineSet can be scaled
+                                    down further, followed by scaling up the new MachineSet, ensuring
+                                    that the total number of machines available at all times
+                                    during the update is at least 70% of desired machines.
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            type:
+                              description: |-
+                                type of deployment. Allowed values are RollingUpdate and OnDelete.
+                                The default is RollingUpdate.
+                              enum:
+                              - RollingUpdate
+                              - OnDelete
+                              type: string
+                          type: object
+                        template:
+                          description: |-
+                            template is a local struct containing a collection of templates for creation of
+                            MachineDeployment objects representing a set of worker nodes.
+                          properties:
+                            bootstrap:
+                              description: |-
+                                bootstrap contains the bootstrap template reference to be used
+                                for the creation of worker Machines.
+                              properties:
+                                ref:
+                                  description: |-
+                                    ref is a required reference to a custom resource
+                                    offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            infrastructure:
+                              description: |-
+                                infrastructure contains the infrastructure template reference to be used
+                                for the creation of worker Machines.
+                              properties:
+                                ref:
+                                  description: |-
+                                    ref is a required reference to a custom resource
+                                    offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            metadata:
+                              description: |-
+                                metadata is the metadata applied to the MachineDeployment and the machines of the MachineDeployment.
+                                At runtime this metadata is merged with the corresponding metadata from the topology.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    annotations is an unstructured key value map stored with a resource that may be
+                                    set by external tools to store and retrieve arbitrary metadata. They are not
+                                    queryable and should be preserved when modifying objects.
+                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    labels is a map of string keys and values that can be used to organize and categorize
+                                    (scope and select) objects. May match selectors of replication controllers
+                                    and services.
+                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                  type: object
+                              type: object
+                          required:
+                          - bootstrap
+                          - infrastructure
+                          type: object
+                      required:
+                      - class
+                      - template
+                      type: object
+                    maxItems: 100
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - class
+                    x-kubernetes-list-type: map
+                  machinePools:
+                    description: |-
+                      machinePools is a list of machine pool classes that can be used to create
+                      a set of worker nodes.
+                    items:
+                      description: |-
+                        MachinePoolClass serves as a template to define a pool of worker nodes of the cluster
+                        provisioned using `ClusterClass`.
+                      properties:
+                        class:
+                          description: |-
+                            class denotes a type of machine pool present in the cluster,
+                            this name MUST be unique within a ClusterClass and can be referenced
+                            in the Cluster to create a managed MachinePool.
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        failureDomains:
+                          description: |-
+                            failureDomains is the list of failure domains the MachinePool should be attached to.
+                            Must match a key in the FailureDomains map stored on the cluster object.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
+                          items:
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          maxItems: 100
+                          type: array
+                        minReadySeconds:
+                          description: |-
+                            minReadySeconds is the minimum number of seconds for which a newly created machine pool should
+                            be ready.
+                            Defaults to 0 (machine will be considered available as soon as it
+                            is ready)
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
+                          format: int32
+                          type: integer
+                        namingStrategy:
+                          description: namingStrategy allows changing the naming pattern
+                            used when creating the MachinePool.
+                          properties:
+                            template:
+                              description: |-
+                                template defines the template to use for generating the name of the MachinePool object.
+                                If not defined, it will fallback to `{{ .cluster.name }}-{{ .machinePool.topologyName }}-{{ .random }}`.
+                                If the templated string exceeds 63 characters, it will be trimmed to 58 characters and will
+                                get concatenated with a random suffix of length 5.
+                                The templating mechanism provides the following arguments:
+                                * `.cluster.name`: The name of the cluster object.
+                                * `.random`: A random alphanumeric string, without vowels, of length 5.
+                                * `.machinePool.topologyName`: The name of the MachinePool topology (Cluster.spec.topology.workers.machinePools[].name).
+                              maxLength: 1024
+                              minLength: 1
+                              type: string
+                          type: object
+                        nodeDeletionTimeout:
+                          description: |-
+                            nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                            hosts after the Machine Pool is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                            Defaults to 10 seconds.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
+                          type: string
+                        nodeDrainTimeout:
+                          description: |-
+                            nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                            The default value is 0, meaning that the node can be drained without any time limitations.
+                            NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
+                          type: string
+                        nodeVolumeDetachTimeout:
+                          description: |-
+                            nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                            to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
+                          type: string
+                        template:
+                          description: |-
+                            template is a local struct containing a collection of templates for creation of
+                            MachinePools objects representing a pool of worker nodes.
+                          properties:
+                            bootstrap:
+                              description: |-
+                                bootstrap contains the bootstrap template reference to be used
+                                for the creation of the Machines in the MachinePool.
+                              properties:
+                                ref:
+                                  description: |-
+                                    ref is a required reference to a custom resource
+                                    offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            infrastructure:
+                              description: |-
+                                infrastructure contains the infrastructure template reference to be used
+                                for the creation of the MachinePool.
+                              properties:
+                                ref:
+                                  description: |-
+                                    ref is a required reference to a custom resource
+                                    offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            metadata:
+                              description: |-
+                                metadata is the metadata applied to the MachinePool.
+                                At runtime this metadata is merged with the corresponding metadata from the topology.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    annotations is an unstructured key value map stored with a resource that may be
+                                    set by external tools to store and retrieve arbitrary metadata. They are not
+                                    queryable and should be preserved when modifying objects.
+                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    labels is a map of string keys and values that can be used to organize and categorize
+                                    (scope and select) objects. May match selectors of replication controllers
+                                    and services.
+                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                  type: object
+                              type: object
+                          required:
+                          - bootstrap
+                          - infrastructure
+                          type: object
+                      required:
+                      - class
+                      - template
+                      type: object
+                    maxItems: 100
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - class
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+          status:
+            description: status is the observed state of ClusterClass.
+            properties:
+              conditions:
+                description: conditions defines current observed state of the ClusterClass.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in ClusterClass's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a ClusterClass's current state.
+                      Known condition types are VariablesReady, RefVersionsUpToDate, Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+              variables:
+                description: variables is a list of ClusterClassStatusVariable that
+                  are defined for the ClusterClass.
+                items:
+                  description: ClusterClassStatusVariable defines a variable which
+                    appears in the status of a ClusterClass.
+                  properties:
+                    definitions:
+                      description: definitions is a list of definitions for a variable.
+                      items:
+                        description: ClusterClassStatusVariableDefinition defines
+                          a variable which appears in the status of a ClusterClass.
+                        properties:
+                          from:
+                            description: |-
+                              from specifies the origin of the variable definition.
+                              This will be `inline` for variables defined in the ClusterClass or the name of a patch defined in the ClusterClass
+                              for variables discovered from a DiscoverVariables runtime extensions.
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          metadata:
+                            description: |-
+                              metadata is the metadata of a variable.
+                              It can be used to add additional data for higher level tools to
+                              a ClusterClassVariable.
+
+                              Deprecated: This field is deprecated and is going to be removed in the next apiVersion.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  annotations is an unstructured key value map that can be used to store and
+                                  retrieve arbitrary metadata.
+                                  They are not queryable.
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  labels is a map of string keys and values that can be used to organize and categorize
+                                  (scope and select) variables.
+                                type: object
+                            type: object
+                          required:
+                            description: |-
+                              required specifies if the variable is required.
+                              Note: this applies to the variable as a whole and thus the
+                              top-level object defined in the schema. If nested fields are
+                              required, this will be specified inside the schema.
+                            type: boolean
+                          schema:
+                            description: schema defines the schema of the variable.
+                            properties:
+                              openAPIV3Schema:
+                                description: |-
+                                  openAPIV3Schema defines the schema of a variable via OpenAPI v3
+                                  schema. The schema is a subset of the schema used in
+                                  Kubernetes CRDs.
+                                properties:
+                                  additionalProperties:
+                                    description: |-
+                                      additionalProperties specifies the schema of values in a map (keys are always strings).
+                                      NOTE: Can only be set if type is object.
+                                      NOTE: AdditionalProperties is mutually exclusive with Properties.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  allOf:
+                                    description: |-
+                                      allOf specifies that the variable must validate against all of the subschemas in the array.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  anyOf:
+                                    description: |-
+                                      anyOf specifies that the variable must validate against one or more of the subschemas in the array.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  default:
+                                    description: |-
+                                      default is the default value of the variable.
+                                      NOTE: Can be set for all types.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  description:
+                                    description: description is a human-readable description
+                                      of this variable.
+                                    maxLength: 4096
+                                    minLength: 1
+                                    type: string
+                                  enum:
+                                    description: |-
+                                      enum is the list of valid values of the variable.
+                                      NOTE: Can be set for all types.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    maxItems: 100
+                                    type: array
+                                  example:
+                                    description: example is an example for this variable.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  exclusiveMaximum:
+                                    description: |-
+                                      exclusiveMaximum specifies if the Maximum is exclusive.
+                                      NOTE: Can only be set if type is integer or number.
+                                    type: boolean
+                                  exclusiveMinimum:
+                                    description: |-
+                                      exclusiveMinimum specifies if the Minimum is exclusive.
+                                      NOTE: Can only be set if type is integer or number.
+                                    type: boolean
+                                  format:
+                                    description: |-
+                                      format is an OpenAPI v3 format string. Unknown formats are ignored.
+                                      For a list of supported formats please see: (of the k8s.io/apiextensions-apiserver version we're currently using)
+                                      https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apiserver/validation/formats.go
+                                      NOTE: Can only be set if type is string.
+                                    maxLength: 32
+                                    minLength: 1
+                                    type: string
+                                  items:
+                                    description: |-
+                                      items specifies fields of an array.
+                                      NOTE: Can only be set if type is array.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  maxItems:
+                                    description: |-
+                                      maxItems is the max length of an array variable.
+                                      NOTE: Can only be set if type is array.
+                                    format: int64
+                                    type: integer
+                                  maxLength:
+                                    description: |-
+                                      maxLength is the max length of a string variable.
+                                      NOTE: Can only be set if type is string.
+                                    format: int64
+                                    type: integer
+                                  maxProperties:
+                                    description: |-
+                                      maxProperties is the maximum amount of entries in a map or properties in an object.
+                                      NOTE: Can only be set if type is object.
+                                    format: int64
+                                    type: integer
+                                  maximum:
+                                    description: |-
+                                      maximum is the maximum of an integer or number variable.
+                                      If ExclusiveMaximum is false, the variable is valid if it is lower than, or equal to, the value of Maximum.
+                                      If ExclusiveMaximum is true, the variable is valid if it is strictly lower than the value of Maximum.
+                                      NOTE: Can only be set if type is integer or number.
+                                    format: int64
+                                    type: integer
+                                  minItems:
+                                    description: |-
+                                      minItems is the min length of an array variable.
+                                      NOTE: Can only be set if type is array.
+                                    format: int64
+                                    type: integer
+                                  minLength:
+                                    description: |-
+                                      minLength is the min length of a string variable.
+                                      NOTE: Can only be set if type is string.
+                                    format: int64
+                                    type: integer
+                                  minProperties:
+                                    description: |-
+                                      minProperties is the minimum amount of entries in a map or properties in an object.
+                                      NOTE: Can only be set if type is object.
+                                    format: int64
+                                    type: integer
+                                  minimum:
+                                    description: |-
+                                      minimum is the minimum of an integer or number variable.
+                                      If ExclusiveMinimum is false, the variable is valid if it is greater than, or equal to, the value of Minimum.
+                                      If ExclusiveMinimum is true, the variable is valid if it is strictly greater than the value of Minimum.
+                                      NOTE: Can only be set if type is integer or number.
+                                    format: int64
+                                    type: integer
+                                  not:
+                                    description: |-
+                                      not specifies that the variable must not validate against the subschema.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  oneOf:
+                                    description: |-
+                                      oneOf specifies that the variable must validate against exactly one of the subschemas in the array.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  pattern:
+                                    description: |-
+                                      pattern is the regex which a string variable must match.
+                                      NOTE: Can only be set if type is string.
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                  properties:
+                                    description: |-
+                                      properties specifies fields of an object.
+                                      NOTE: Can only be set if type is object.
+                                      NOTE: Properties is mutually exclusive with AdditionalProperties.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  required:
+                                    description: |-
+                                      required specifies which fields of an object are required.
+                                      NOTE: Can only be set if type is object.
+                                    items:
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                    maxItems: 1000
+                                    type: array
+                                  type:
+                                    description: |-
+                                      type is the type of the variable.
+                                      Valid values are: object, array, string, integer, number or boolean.
+                                    enum:
+                                    - object
+                                    - array
+                                    - string
+                                    - integer
+                                    - number
+                                    - boolean
+                                    type: string
+                                  uniqueItems:
+                                    description: |-
+                                      uniqueItems specifies if items in an array must be unique.
+                                      NOTE: Can only be set if type is array.
+                                    type: boolean
+                                  x-kubernetes-int-or-string:
+                                    description: |-
+                                      x-kubernetes-int-or-string specifies that this value is
+                                      either an integer or a string. If this is true, an empty
+                                      type is allowed and type as child of anyOf is permitted
+                                      if following one of the following patterns:
+
+                                      1) anyOf:
+                                         - type: integer
+                                         - type: string
+                                      2) allOf:
+                                         - anyOf:
+                                           - type: integer
+                                           - type: string
+                                         - ... zero or more
+                                    type: boolean
+                                  x-kubernetes-preserve-unknown-fields:
+                                    description: |-
+                                      x-kubernetes-preserve-unknown-fields allows setting fields in a variable object
+                                      which are not defined in the variable schema. This affects fields recursively,
+                                      except if nested properties or additionalProperties are specified in the schema.
+                                    type: boolean
+                                  x-kubernetes-validations:
+                                    description: x-kubernetes-validations describes
+                                      a list of validation rules written in the CEL
+                                      expression language.
+                                    items:
+                                      description: ValidationRule describes a validation
+                                        rule written in the CEL expression language.
+                                      properties:
+                                        fieldPath:
+                                          description: |-
+                                            fieldPath represents the field path returned when the validation fails.
+                                            It must be a relative JSON path (i.e. with array notation) scoped to the location of this x-kubernetes-validations extension in the schema and refer to an existing field.
+                                            e.g. when validation checks if a specific attribute `foo` under a map `testMap`, the fieldPath could be set to `.testMap.foo`
+                                            If the validation checks two lists must have unique attributes, the fieldPath could be set to either of the list: e.g. `.testList`
+                                            It does not support list numeric index.
+                                            It supports child operation to refer to an existing field currently. Refer to [JSONPath support in Kubernetes](https://kubernetes.io/docs/reference/kubectl/jsonpath/) for more info.
+                                            Numeric index of array is not supported.
+                                            For field name which contains special characters, use `['specialName']` to refer the field name.
+                                            e.g. for attribute `foo.34$` appears in a list `testList`, the fieldPath could be set to `.testList['foo.34$']`
+                                          maxLength: 512
+                                          minLength: 1
+                                          type: string
+                                        message:
+                                          description: |-
+                                            message represents the message displayed when validation fails. The message is required if the Rule contains
+                                            line breaks. The message must not contain line breaks.
+                                            If unset, the message is "failed rule: {Rule}".
+                                            e.g. "must be a URL with the host matching spec.host"
+                                          maxLength: 512
+                                          minLength: 1
+                                          type: string
+                                        messageExpression:
+                                          description: |-
+                                            messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails.
+                                            Since messageExpression is used as a failure message, it must evaluate to a string.
+                                            If both message and messageExpression are present on a rule, then messageExpression will be used if validation
+                                            fails. If messageExpression results in a runtime error, the validation failure message is produced
+                                            as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string
+                                            that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset.
+                                            messageExpression has access to all the same variables as the rule; the only difference is the return type.
+                                            Example:
+                                            "x must be less than max ("+string(self.max)+")"
+                                          maxLength: 1024
+                                          minLength: 1
+                                          type: string
+                                        reason:
+                                          default: FieldValueInvalid
+                                          description: |-
+                                            reason provides a machine-readable validation failure reason that is returned to the caller when a request fails this validation rule.
+                                            The currently supported reasons are: "FieldValueInvalid", "FieldValueForbidden", "FieldValueRequired", "FieldValueDuplicate".
+                                            If not set, default to use "FieldValueInvalid".
+                                            All future added reasons must be accepted by clients when reading this value and unknown reasons should be treated as FieldValueInvalid.
+                                          enum:
+                                          - FieldValueInvalid
+                                          - FieldValueForbidden
+                                          - FieldValueRequired
+                                          - FieldValueDuplicate
+                                          type: string
+                                        rule:
+                                          description: "rule represents the expression
+                                            which will be evaluated by CEL.\nref:
+                                            https://github.com/google/cel-spec\nThe
+                                            Rule is scoped to the location of the
+                                            x-kubernetes-validations extension in
+                                            the schema.\nThe `self` variable in the
+                                            CEL expression is bound to the scoped
+                                            value.\nIf the Rule is scoped to an object
+                                            with properties, the accessible properties
+                                            of the object are field selectable\nvia
+                                            `self.field` and field presence can be
+                                            checked via `has(self.field)`.\nIf the
+                                            Rule is scoped to an object with additionalProperties
+                                            (i.e. a map) the value of the map\nare
+                                            accessible via `self[mapKey]`, map containment
+                                            can be checked via `mapKey in self` and
+                                            all entries of the map\nare accessible
+                                            via CEL macros and functions such as `self.all(...)`.\nIf
+                                            the Rule is scoped to an array, the elements
+                                            of the array are accessible via `self[i]`
+                                            and also by macros and\nfunctions.\nIf
+                                            the Rule is scoped to a scalar, `self`
+                                            is bound to the scalar value.\nExamples:\n-
+                                            Rule scoped to a map of objects: {\"rule\":
+                                            \"self.components['Widget'].priority <
+                                            10\"}\n- Rule scoped to a list of integers:
+                                            {\"rule\": \"self.values.all(value, value
+                                            >= 0 && value < 100)\"}\n- Rule scoped
+                                            to a string value: {\"rule\": \"self.startsWith('kube')\"}\n\nUnknown
+                                            data preserved in custom resources via
+                                            x-kubernetes-preserve-unknown-fields is
+                                            not accessible in CEL\nexpressions. This
+                                            includes:\n- Unknown field values that
+                                            are preserved by object schemas with x-kubernetes-preserve-unknown-fields.\n-
+                                            Object properties where the property schema
+                                            is of an \"unknown type\". An \"unknown
+                                            type\" is recursively defined as:\n  -
+                                            A schema with no type and x-kubernetes-preserve-unknown-fields
+                                            set to true\n  - An array where the items
+                                            schema is of an \"unknown type\"\n  -
+                                            An object where the additionalProperties
+                                            schema is of an \"unknown type\"\n\nOnly
+                                            property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*`
+                                            are accessible.\nAccessible property names
+                                            are escaped according to the following
+                                            rules when accessed in the expression:\n-
+                                            '__' escapes to '__underscores__'\n- '.'
+                                            escapes to '__dot__'\n- '-' escapes to
+                                            '__dash__'\n- '/' escapes to '__slash__'\n-
+                                            Property names that exactly match a CEL
+                                            RESERVED keyword escape to '__{keyword}__'.
+                                            The keywords are:\n\t  \"true\", \"false\",
+                                            \"null\", \"in\", \"as\", \"break\", \"const\",
+                                            \"continue\", \"else\", \"for\", \"function\",
+                                            \"if\",\n\t  \"import\", \"let\", \"loop\",
+                                            \"package\", \"namespace\", \"return\".\nExamples:\n
+                                            \ - Rule accessing a property named \"namespace\":
+                                            {\"rule\": \"self.__namespace__ > 0\"}\n
+                                            \ - Rule accessing a property named \"x-prop\":
+                                            {\"rule\": \"self.x__dash__prop > 0\"}\n
+                                            \ - Rule accessing a property named \"redact__d\":
+                                            {\"rule\": \"self.redact__underscores__d
+                                            > 0\"}\n\nIf `rule` makes use of the `oldSelf`
+                                            variable it is implicitly a\n`transition
+                                            rule`.\n\nBy default, the `oldSelf` variable
+                                            is the same type as `self`.\n\nTransition
+                                            rules by default are applied only on UPDATE
+                                            requests and are\nskipped if an old value
+                                            could not be found."
+                                          maxLength: 4096
+                                          minLength: 1
+                                          type: string
+                                      required:
+                                      - rule
+                                      type: object
+                                    maxItems: 100
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - rule
+                                    x-kubernetes-list-type: map
+                                  x-metadata:
+                                    description: |-
+                                      x-metadata is the metadata of a variable or a nested field within a variable.
+                                      It can be used to add additional data for higher level tools.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          annotations is an unstructured key value map that can be used to store and
+                                          retrieve arbitrary metadata.
+                                          They are not queryable.
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          labels is a map of string keys and values that can be used to organize and categorize
+                                          (scope and select) variables.
+                                        type: object
+                                    type: object
+                                type: object
+                            required:
+                            - openAPIV3Schema
+                            type: object
+                        required:
+                        - from
+                        - required
+                        - schema
+                        type: object
+                      maxItems: 100
+                      type: array
+                    definitionsConflict:
+                      description: definitionsConflict specifies whether or not there
+                        are conflicting definitions for a single variable name.
+                      type: boolean
+                    name:
+                      description: name is the name of the variable.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - definitions
+                  - name
+                  type: object
+                maxItems: 1000
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.17.2
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: clusterresourcesetbindings.addons.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: addons.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ClusterResourceSetBinding
+    listKind: ClusterResourceSetBindingList
+    plural: clusterresourcesetbindings
+    singular: clusterresourcesetbinding
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of ClusterResourceSetBinding.
+            properties:
+              bindings:
+                description: bindings is a list of ClusterResourceSets and their resources.
+                items:
+                  description: ResourceSetBinding keeps info on all of the resources
+                    in a ClusterResourceSet.
+                  properties:
+                    clusterResourceSetName:
+                      description: clusterResourceSetName is the name of the ClusterResourceSet
+                        that is applied to the owner cluster of the binding.
+                      type: string
+                    resources:
+                      description: resources is a list of resources that the ClusterResourceSet
+                        has.
+                      items:
+                        description: ResourceBinding shows the status of a resource
+                          that belongs to a ClusterResourceSet matched by the owner
+                          cluster of the ClusterResourceSetBinding object.
+                        properties:
+                          applied:
+                            description: applied is to track if a resource is applied
+                              to the cluster or not.
+                            type: boolean
+                          hash:
+                            description: |-
+                              hash is the hash of a resource's data. This can be used to decide if a resource is changed.
+                              For "ApplyOnce" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.
+                            type: string
+                          kind:
+                            description: 'kind of the resource. Supported kinds are:
+                              Secrets and ConfigMaps.'
+                            enum:
+                            - Secret
+                            - ConfigMap
+                            type: string
+                          lastAppliedTime:
+                            description: lastAppliedTime identifies when this resource
+                              was last applied to the cluster.
+                            format: date-time
+                            type: string
+                          name:
+                            description: name of the resource that is in the same
+                              namespace with ClusterResourceSet object.
+                            minLength: 1
+                            type: string
+                        required:
+                        - applied
+                        - kind
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - clusterResourceSetName
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSetBinding
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of ClusterResourceSetBinding.
+            properties:
+              bindings:
+                description: bindings is a list of ClusterResourceSets and their resources.
+                items:
+                  description: ResourceSetBinding keeps info on all of the resources
+                    in a ClusterResourceSet.
+                  properties:
+                    clusterResourceSetName:
+                      description: clusterResourceSetName is the name of the ClusterResourceSet
+                        that is applied to the owner cluster of the binding.
+                      type: string
+                    resources:
+                      description: resources is a list of resources that the ClusterResourceSet
+                        has.
+                      items:
+                        description: ResourceBinding shows the status of a resource
+                          that belongs to a ClusterResourceSet matched by the owner
+                          cluster of the ClusterResourceSetBinding object.
+                        properties:
+                          applied:
+                            description: applied is to track if a resource is applied
+                              to the cluster or not.
+                            type: boolean
+                          hash:
+                            description: |-
+                              hash is the hash of a resource's data. This can be used to decide if a resource is changed.
+                              For "ApplyOnce" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.
+                            type: string
+                          kind:
+                            description: 'kind of the resource. Supported kinds are:
+                              Secrets and ConfigMaps.'
+                            enum:
+                            - Secret
+                            - ConfigMap
+                            type: string
+                          lastAppliedTime:
+                            description: lastAppliedTime identifies when this resource
+                              was last applied to the cluster.
+                            format: date-time
+                            type: string
+                          name:
+                            description: name of the resource that is in the same
+                              namespace with ClusterResourceSet object.
+                            minLength: 1
+                            type: string
+                        required:
+                        - applied
+                        - kind
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - clusterResourceSetName
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSetBinding
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSetBinding lists all matching ClusterResourceSets
+          with the cluster it belongs to.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of ClusterResourceSetBinding.
+            properties:
+              bindings:
+                description: bindings is a list of ClusterResourceSets and their resources.
+                items:
+                  description: ResourceSetBinding keeps info on all of the resources
+                    in a ClusterResourceSet.
+                  properties:
+                    clusterResourceSetName:
+                      description: clusterResourceSetName is the name of the ClusterResourceSet
+                        that is applied to the owner cluster of the binding.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    resources:
+                      description: resources is a list of resources that the ClusterResourceSet
+                        has.
+                      items:
+                        description: ResourceBinding shows the status of a resource
+                          that belongs to a ClusterResourceSet matched by the owner
+                          cluster of the ClusterResourceSetBinding object.
+                        properties:
+                          applied:
+                            description: applied is to track if a resource is applied
+                              to the cluster or not.
+                            type: boolean
+                          hash:
+                            description: |-
+                              hash is the hash of a resource's data. This can be used to decide if a resource is changed.
+                              For "ApplyOnce" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          kind:
+                            description: 'kind of the resource. Supported kinds are:
+                              Secrets and ConfigMaps.'
+                            enum:
+                            - Secret
+                            - ConfigMap
+                            type: string
+                          lastAppliedTime:
+                            description: lastAppliedTime identifies when this resource
+                              was last applied to the cluster.
+                            format: date-time
+                            type: string
+                          name:
+                            description: name of the resource that is in the same
+                              namespace with ClusterResourceSet object.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                        required:
+                        - applied
+                        - kind
+                        - name
+                        type: object
+                      maxItems: 100
+                      type: array
+                  required:
+                  - clusterResourceSetName
+                  type: object
+                maxItems: 100
+                type: array
+              clusterName:
+                description: |-
+                  clusterName is the name of the Cluster this binding applies to.
+                  Note: this field mandatory in v1beta2.
+                maxLength: 63
+                minLength: 1
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.17.2
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: clusterresourcesets.addons.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: addons.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ClusterResourceSet
+    listKind: ClusterResourceSetList
+    plural: clusterresourcesets
+    singular: clusterresourceset
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterResourceSet is the Schema for the clusterresourcesets API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of ClusterResourceSet.
+            properties:
+              clusterSelector:
+                description: |-
+                  clusterSelector is the label selector for Clusters. The Clusters that are
+                  selected by this will be the ones affected by this ClusterResourceSet.
+                  It must match the Cluster labels. This field is immutable.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              resources:
+                description: resources is a list of Secrets/ConfigMaps where each
+                  contains 1 or more resources to be applied to remote clusters.
+                items:
+                  description: ResourceRef specifies a resource.
+                  properties:
+                    kind:
+                      description: 'kind of the resource. Supported kinds are: Secrets
+                        and ConfigMaps.'
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: name of the resource that is in the same namespace
+                        with ClusterResourceSet object.
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              strategy:
+                description: strategy is the strategy to be used during applying resources.
+                  Defaults to ApplyOnce. This field is immutable.
+                enum:
+                - ApplyOnce
+                type: string
+            required:
+            - clusterSelector
+            type: object
+          status:
+            description: status is the observed state of ClusterResourceSet.
+            properties:
+              conditions:
+                description: conditions defines current state of the ClusterResourceSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration reflects the generation of the most
+                  recently observed ClusterResourceSet.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterResourceSet is the Schema for the clusterresourcesets API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of ClusterResourceSet.
+            properties:
+              clusterSelector:
+                description: |-
+                  clusterSelector is the label selector for Clusters. The Clusters that are
+                  selected by this will be the ones affected by this ClusterResourceSet.
+                  It must match the Cluster labels. This field is immutable.
+                  Label selector cannot be empty.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              resources:
+                description: resources is a list of Secrets/ConfigMaps where each
+                  contains 1 or more resources to be applied to remote clusters.
+                items:
+                  description: ResourceRef specifies a resource.
+                  properties:
+                    kind:
+                      description: 'kind of the resource. Supported kinds are: Secrets
+                        and ConfigMaps.'
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: name of the resource that is in the same namespace
+                        with ClusterResourceSet object.
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              strategy:
+                description: strategy is the strategy to be used during applying resources.
+                  Defaults to ApplyOnce. This field is immutable.
+                enum:
+                - ApplyOnce
+                type: string
+            required:
+            - clusterSelector
+            type: object
+          status:
+            description: status is the observed state of ClusterResourceSet.
+            properties:
+              conditions:
+                description: conditions defines current state of the ClusterResourceSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration reflects the generation of the most
+                  recently observed ClusterResourceSet.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterResourceSet is the Schema for the clusterresourcesets API.
+          For advanced use cases an add-on provider should be used instead.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of ClusterResourceSet.
+            properties:
+              clusterSelector:
+                description: |-
+                  clusterSelector is the label selector for Clusters. The Clusters that are
+                  selected by this will be the ones affected by this ClusterResourceSet.
+                  It must match the Cluster labels. This field is immutable.
+                  Label selector cannot be empty.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              resources:
+                description: resources is a list of Secrets/ConfigMaps where each
+                  contains 1 or more resources to be applied to remote clusters.
+                items:
+                  description: ResourceRef specifies a resource.
+                  properties:
+                    kind:
+                      description: 'kind of the resource. Supported kinds are: Secrets
+                        and ConfigMaps.'
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: name of the resource that is in the same namespace
+                        with ClusterResourceSet object.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                maxItems: 100
+                type: array
+              strategy:
+                description: strategy is the strategy to be used during applying resources.
+                  Defaults to ApplyOnce. This field is immutable.
+                enum:
+                - ApplyOnce
+                - Reconcile
+                type: string
+            required:
+            - clusterSelector
+            type: object
+          status:
+            description: status is the observed state of ClusterResourceSet.
+            properties:
+              conditions:
+                description: conditions defines current state of the ClusterResourceSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration reflects the generation of the most
+                  recently observed ClusterResourceSet.
+                format: int64
+                type: integer
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in ClusterResourceSet's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a ClusterResourceSet's current state.
+                      Known condition types are ResourceSetApplied, Deleting.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.17.2
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: clusters.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    shortNames:
+    - cl
+    singular: cluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster status such as Pending/Provisioning/Provisioned/Deleting/Failed
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the clusters API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of Cluster.
+            properties:
+              clusterNetwork:
+                description: clusterNetwork is the cluster network configuration.
+                properties:
+                  apiServerPort:
+                    description: |-
+                      apiServerPort specifies the port the API Server should bind to.
+                      Defaults to 6443.
+                    format: int32
+                    type: integer
+                  pods:
+                    description: pods is the network ranges from which Pod networks
+                      are allocated.
+                    properties:
+                      cidrBlocks:
+                        description: cidrBlocks is a list of CIDR blocks.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                  serviceDomain:
+                    description: serviceDomain is the domain name for services.
+                    type: string
+                  services:
+                    description: services is the network ranges from which service
+                      VIPs are allocated.
+                    properties:
+                      cidrBlocks:
+                        description: cidrBlocks is a list of CIDR blocks.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                type: object
+              controlPlaneEndpoint:
+                description: controlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: host is the hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: port is the port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controlPlaneRef:
+                description: |-
+                  controlPlaneRef is an optional reference to a provider-specific resource that holds
+                  the details for provisioning the Control Plane for a Cluster.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              infrastructureRef:
+                description: |-
+                  infrastructureRef is a reference to a provider-specific resource that holds the details
+                  for provisioning infrastructure for a cluster in said provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              paused:
+                description: paused can be used to prevent controllers from processing
+                  the Cluster and all its associated objects.
+                type: boolean
+            type: object
+          status:
+            description: status is the observed state of Cluster.
+            properties:
+              conditions:
+                description: conditions defines current service state of the cluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              controlPlaneInitialized:
+                description: controlPlaneInitialized defines if the control plane
+                  has been initialized.
+                type: boolean
+              controlPlaneReady:
+                description: controlPlaneReady defines if the control plane is ready.
+                type: boolean
+              failureDomains:
+                additionalProperties:
+                  description: |-
+                    FailureDomainSpec is the Schema for Cluster API failure domains.
+                    It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: controlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: failureDomains is a slice of failure domain objects synced
+                  from the infrastructure provider.
+                type: object
+              failureMessage:
+                description: |-
+                  failureMessage indicates that there is a fatal problem reconciling the
+                  state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason indicates that there is a fatal problem reconciling the
+                  state, and will be set to a token value suitable for
+                  programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: |-
+                  phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of Cluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Cluster status such as Pending/Provisioning/Provisioned/Deleting/Failed
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Cluster is the Schema for the clusters API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of Cluster.
+            properties:
+              clusterNetwork:
+                description: clusterNetwork is the cluster network configuration.
+                properties:
+                  apiServerPort:
+                    description: |-
+                      apiServerPort specifies the port the API Server should bind to.
+                      Defaults to 6443.
+                    format: int32
+                    type: integer
+                  pods:
+                    description: pods is the network ranges from which Pod networks
+                      are allocated.
+                    properties:
+                      cidrBlocks:
+                        description: cidrBlocks is a list of CIDR blocks.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                  serviceDomain:
+                    description: serviceDomain is the domain name for services.
+                    type: string
+                  services:
+                    description: services is the network ranges from which service
+                      VIPs are allocated.
+                    properties:
+                      cidrBlocks:
+                        description: cidrBlocks is a list of CIDR blocks.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                type: object
+              controlPlaneEndpoint:
+                description: controlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: host is the hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: port is the port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controlPlaneRef:
+                description: |-
+                  controlPlaneRef is an optional reference to a provider-specific resource that holds
+                  the details for provisioning the Control Plane for a Cluster.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              infrastructureRef:
+                description: |-
+                  infrastructureRef is a reference to a provider-specific resource that holds the details
+                  for provisioning infrastructure for a cluster in said provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              paused:
+                description: paused can be used to prevent controllers from processing
+                  the Cluster and all its associated objects.
+                type: boolean
+              topology:
+                description: |-
+                  topology encapsulates the topology for the cluster.
+                  NOTE: It is required to enable the ClusterTopology
+                  feature gate flag to activate managed topologies support;
+                  this feature is highly experimental, and parts of it might still be not implemented.
+                properties:
+                  class:
+                    description: class is the name of the ClusterClass object to create
+                      the topology.
+                    type: string
+                  controlPlane:
+                    description: controlPlane describes the cluster control plane.
+                    properties:
+                      metadata:
+                        description: |-
+                          metadata is the metadata applied to the machines of the ControlPlane.
+                          At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+
+                          This field is supported if and only if the control plane provider template
+                          referenced in the ClusterClass is Machine based.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              annotations is an unstructured key value map stored with a resource that may be
+                              set by external tools to store and retrieve arbitrary metadata. They are not
+                              queryable and should be preserved when modifying objects.
+                              More info: http://kubernetes.io/docs/user-guide/annotations
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              labels is a map of string keys and values that can be used to organize and categorize
+                              (scope and select) objects. May match selectors of replication controllers
+                              and services.
+                              More info: http://kubernetes.io/docs/user-guide/labels
+                            type: object
+                        type: object
+                      replicas:
+                        description: |-
+                          replicas is the number of control plane nodes.
+                          If the value is nil, the ControlPlane object is created without the number of Replicas
+                          and it's assumed that the control plane controller does not implement support for this field.
+                          When specified against a control plane provider that lacks support for this field, this value will be ignored.
+                        format: int32
+                        type: integer
+                    type: object
+                  rolloutAfter:
+                    description: |-
+                      rolloutAfter performs a rollout of the entire cluster one component at a time,
+                      control plane first and then machine deployments.
+                    format: date-time
+                    type: string
+                  version:
+                    description: version is the Kubernetes version of the cluster.
+                    type: string
+                  workers:
+                    description: |-
+                      workers encapsulates the different constructs that form the worker nodes
+                      for the cluster.
+                    properties:
+                      machineDeployments:
+                        description: machineDeployments is a list of machine deployments
+                          in the cluster.
+                        items:
+                          description: |-
+                            MachineDeploymentTopology specifies the different parameters for a set of worker nodes in the topology.
+                            This set of nodes is managed by a MachineDeployment object whose lifecycle is managed by the Cluster controller.
+                          properties:
+                            class:
+                              description: |-
+                                class is the name of the MachineDeploymentClass used to create the set of worker nodes.
+                                This should match one of the deployment classes defined in the ClusterClass object
+                                mentioned in the `Cluster.Spec.Class` field.
+                              type: string
+                            metadata:
+                              description: |-
+                                metadata is the metadata applied to the machines of the MachineDeployment.
+                                At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    annotations is an unstructured key value map stored with a resource that may be
+                                    set by external tools to store and retrieve arbitrary metadata. They are not
+                                    queryable and should be preserved when modifying objects.
+                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    labels is a map of string keys and values that can be used to organize and categorize
+                                    (scope and select) objects. May match selectors of replication controllers
+                                    and services.
+                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                  type: object
+                              type: object
+                            name:
+                              description: |-
+                                name is the unique identifier for this MachineDeploymentTopology.
+                                The value is used with other unique identifiers to create a MachineDeployment's Name
+                                (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
+                                the values are hashed together.
+                              type: string
+                            replicas:
+                              description: |-
+                                replicas is the number of worker nodes belonging to this set.
+                                If the value is nil, the MachineDeployment is created without the number of Replicas (defaulting to zero)
+                                and it's assumed that an external entity (like cluster autoscaler) is responsible for the management
+                                of this value.
+                              format: int32
+                              type: integer
+                          required:
+                          - class
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                required:
+                - class
+                - version
+                type: object
+            type: object
+          status:
+            description: status is the observed state of Cluster.
+            properties:
+              conditions:
+                description: conditions defines current service state of the cluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              controlPlaneReady:
+                description: controlPlaneReady defines if the control plane is ready.
+                type: boolean
+              failureDomains:
+                additionalProperties:
+                  description: |-
+                    FailureDomainSpec is the Schema for Cluster API failure domains.
+                    It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: controlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: failureDomains is a slice of failure domain objects synced
+                  from the infrastructure provider.
+                type: object
+              failureMessage:
+                description: |-
+                  failureMessage indicates that there is a fatal problem reconciling the
+                  state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason indicates that there is a fatal problem reconciling the
+                  state, and will be set to a token value suitable for
+                  programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: |-
+                  phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: ClusterClass of this Cluster, empty if the Cluster is not using
+        a ClusterClass
+      jsonPath: .spec.topology.class
+      name: ClusterClass
+      type: string
+    - description: Cluster status such as Pending/Provisioning/Provisioned/Deleting/Failed
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of Cluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this Cluster
+      jsonPath: .spec.topology.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the clusters API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of Cluster.
+            properties:
+              availabilityGates:
+                description: |-
+                  availabilityGates specifies additional conditions to include when evaluating Cluster Available condition.
+
+                  If this field is not defined and the Cluster implements a managed topology, availabilityGates
+                  from the corresponding ClusterClass will be used, if any.
+
+                  NOTE: this field is considered only for computing v1beta2 conditions.
+                items:
+                  description: ClusterAvailabilityGate contains the type of a Cluster
+                    condition to be used as availability gate.
+                  properties:
+                    conditionType:
+                      description: |-
+                        conditionType refers to a condition with matching type in the Cluster's condition list.
+                        If the conditions doesn't exist, it will be treated as unknown.
+                        Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as availability gates.
+                      maxLength: 316
+                      minLength: 1
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                    polarity:
+                      description: |-
+                        polarity of the conditionType specified in this availabilityGate.
+                        Valid values are Positive, Negative and omitted.
+                        When omitted, the default behaviour will be Positive.
+                        A positive polarity means that the condition should report a true status under normal conditions.
+                        A negative polarity means that the condition should report a false status under normal conditions.
+                      enum:
+                      - Positive
+                      - Negative
+                      type: string
+                  required:
+                  - conditionType
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - conditionType
+                x-kubernetes-list-type: map
+              clusterNetwork:
+                description: clusterNetwork represents the cluster network configuration.
+                properties:
+                  apiServerPort:
+                    description: |-
+                      apiServerPort specifies the port the API Server should bind to.
+                      Defaults to 6443.
+                    format: int32
+                    type: integer
+                  pods:
+                    description: pods is the network ranges from which Pod networks
+                      are allocated.
+                    properties:
+                      cidrBlocks:
+                        description: cidrBlocks is a list of CIDR blocks.
+                        items:
+                          maxLength: 43
+                          minLength: 1
+                          type: string
+                        maxItems: 100
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                  serviceDomain:
+                    description: serviceDomain is the domain name for services.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  services:
+                    description: services is the network ranges from which service
+                      VIPs are allocated.
+                    properties:
+                      cidrBlocks:
+                        description: cidrBlocks is a list of CIDR blocks.
+                        items:
+                          maxLength: 43
+                          minLength: 1
+                          type: string
+                        maxItems: 100
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                type: object
+              controlPlaneEndpoint:
+                description: controlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: host is the hostname on which the API server is serving.
+                    maxLength: 512
+                    type: string
+                  port:
+                    description: port is the port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controlPlaneRef:
+                description: |-
+                  controlPlaneRef is an optional reference to a provider-specific resource that holds
+                  the details for provisioning the Control Plane for a Cluster.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              infrastructureRef:
+                description: |-
+                  infrastructureRef is a reference to a provider-specific resource that holds the details
+                  for provisioning infrastructure for a cluster in said provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              paused:
+                description: paused can be used to prevent controllers from processing
+                  the Cluster and all its associated objects.
+                type: boolean
+              topology:
+                description: |-
+                  topology encapsulates the topology for the cluster.
+                  NOTE: It is required to enable the ClusterTopology
+                  feature gate flag to activate managed topologies support;
+                  this feature is highly experimental, and parts of it might still be not implemented.
+                properties:
+                  class:
+                    description: class is the name of the ClusterClass object to create
+                      the topology.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  classNamespace:
+                    description: |-
+                      classNamespace is the namespace of the ClusterClass that should be used for the topology.
+                      If classNamespace is empty or not set, it is defaulted to the namespace of the Cluster object.
+                      classNamespace must be a valid namespace name and because of that be at most 63 characters in length
+                      and it must consist only of lower case alphanumeric characters or hyphens (-), and must start
+                      and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                  controlPlane:
+                    description: controlPlane describes the cluster control plane.
+                    properties:
+                      machineHealthCheck:
+                        description: |-
+                          machineHealthCheck allows to enable, disable and override
+                          the MachineHealthCheck configuration in the ClusterClass for this control plane.
+                        properties:
+                          enable:
+                            description: |-
+                              enable controls if a MachineHealthCheck should be created for the target machines.
+
+                              If false: No MachineHealthCheck will be created.
+
+                              If not set(default): A MachineHealthCheck will be created if it is defined here or
+                               in the associated ClusterClass. If no MachineHealthCheck is defined then none will be created.
+
+                              If true: A MachineHealthCheck is guaranteed to be created. Cluster validation will
+                              block if `enable` is true and no MachineHealthCheck definition is available.
+                            type: boolean
+                          maxUnhealthy:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                              Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
+                              "selector" are not healthy.
+                            x-kubernetes-int-or-string: true
+                          nodeStartupTimeout:
+                            description: |-
+                              nodeStartupTimeout allows to set the maximum time for MachineHealthCheck
+                              to consider a Machine unhealthy if a corresponding Node isn't associated
+                              through a `Spec.ProviderID` field.
+
+                              The duration set in this field is compared to the greatest of:
+                              - Cluster's infrastructure ready condition timestamp (if and when available)
+                              - Control Plane's initialized condition timestamp (if and when available)
+                              - Machine's infrastructure ready condition timestamp (if and when available)
+                              - Machine's metadata creation timestamp
+
+                              Defaults to 10 minutes.
+                              If you wish to disable this feature, set the value explicitly to 0.
+                            type: string
+                          remediationTemplate:
+                            description: |-
+                              remediationTemplate is a reference to a remediation template
+                              provided by an infrastructure provider.
+
+                              This field is completely optional, when filled, the MachineHealthCheck controller
+                              creates a new object from the template referenced and hands off remediation of the machine to
+                              a controller that lives outside of Cluster API.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          unhealthyConditions:
+                            description: |-
+                              unhealthyConditions contains a list of the conditions that determine
+                              whether a node is considered unhealthy. The conditions are combined in a
+                              logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                            items:
+                              description: |-
+                                UnhealthyCondition represents a Node condition type and value with a timeout
+                                specified as a duration.  When the named condition has been in the given
+                                status for at least the timeout value, a node is considered unhealthy.
+                              properties:
+                                status:
+                                  description: status of the condition, one of True,
+                                    False, Unknown.
+                                  minLength: 1
+                                  type: string
+                                timeout:
+                                  description: |-
+                                    timeout is the duration that a node must be in a given status for,
+                                    after which the node is considered unhealthy.
+                                    For example, with a value of "1h", the node must match the status
+                                    for at least 1 hour before being considered unhealthy.
+                                  type: string
+                                type:
+                                  description: type of Node condition
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - status
+                              - timeout
+                              - type
+                              type: object
+                            maxItems: 100
+                            type: array
+                          unhealthyRange:
+                            description: |-
+                              unhealthyRange specifies the range of unhealthy machines allowed.
+                              Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
+                              is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
+                              Eg. "[3-5]" - This means that remediation will be allowed only when:
+                              (a) there are at least 3 unhealthy machines (and)
+                              (b) there are at most 5 unhealthy machines
+                            maxLength: 32
+                            minLength: 1
+                            pattern: ^\[[0-9]+-[0-9]+\]$
+                            type: string
+                        type: object
+                      metadata:
+                        description: |-
+                          metadata is the metadata applied to the ControlPlane and the Machines of the ControlPlane
+                          if the ControlPlaneTemplate referenced by the ClusterClass is machine based. If not, it
+                          is applied only to the ControlPlane.
+                          At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              annotations is an unstructured key value map stored with a resource that may be
+                              set by external tools to store and retrieve arbitrary metadata. They are not
+                              queryable and should be preserved when modifying objects.
+                              More info: http://kubernetes.io/docs/user-guide/annotations
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              labels is a map of string keys and values that can be used to organize and categorize
+                              (scope and select) objects. May match selectors of replication controllers
+                              and services.
+                              More info: http://kubernetes.io/docs/user-guide/labels
+                            type: object
+                        type: object
+                      nodeDeletionTimeout:
+                        description: |-
+                          nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                          hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                          Defaults to 10 seconds.
+                        type: string
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: |-
+                          nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                        type: string
+                      readinessGates:
+                        description: |-
+                          readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                          This field can be used e.g. to instruct the machine controller to include in the computation for Machine's ready
+                          computation a condition, managed by an external controllers, reporting the status of special software/hardware installed on the Machine.
+
+                          If this field is not defined, readinessGates from the corresponding ControlPlaneClass will be used, if any.
+
+                          NOTE: This field is considered only for computing v1beta2 conditions.
+                          NOTE: Specific control plane provider implementations might automatically extend the list of readinessGates;
+                          e.g. the kubeadm control provider adds ReadinessGates for the APIServerPodHealthy, SchedulerPodHealthy conditions, etc.
+                        items:
+                          description: MachineReadinessGate contains the type of a
+                            Machine condition to be used as a readiness gate.
+                          properties:
+                            conditionType:
+                              description: |-
+                                conditionType refers to a condition with matching type in the Machine's condition list.
+                                If the conditions doesn't exist, it will be treated as unknown.
+                                Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                              maxLength: 316
+                              minLength: 1
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                            polarity:
+                              description: |-
+                                polarity of the conditionType specified in this readinessGate.
+                                Valid values are Positive, Negative and omitted.
+                                When omitted, the default behaviour will be Positive.
+                                A positive polarity means that the condition should report a true status under normal conditions.
+                                A negative polarity means that the condition should report a false status under normal conditions.
+                              enum:
+                              - Positive
+                              - Negative
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - conditionType
+                        x-kubernetes-list-type: map
+                      replicas:
+                        description: |-
+                          replicas is the number of control plane nodes.
+                          If the value is nil, the ControlPlane object is created without the number of Replicas
+                          and it's assumed that the control plane controller does not implement support for this field.
+                          When specified against a control plane provider that lacks support for this field, this value will be ignored.
+                        format: int32
+                        type: integer
+                      variables:
+                        description: variables can be used to customize the ControlPlane
+                          through patches.
+                        properties:
+                          overrides:
+                            description: overrides can be used to override Cluster
+                              level variables.
+                            items:
+                              description: |-
+                                ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a
+                                Variable definition in the ClusterClass `status` variables.
+                              properties:
+                                definitionFrom:
+                                  description: |-
+                                    definitionFrom specifies where the definition of this Variable is from.
+
+                                    Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                                  maxLength: 256
+                                  type: string
+                                name:
+                                  description: name of the variable.
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                value:
+                                  description: |-
+                                    value of the variable.
+                                    Note: the value will be validated against the schema of the corresponding ClusterClassVariable
+                                    from the ClusterClass.
+                                    Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a
+                                    hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools,
+                                    i.e. it is not possible to have no type field.
+                                    Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111
+                                  x-kubernetes-preserve-unknown-fields: true
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 1000
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                        type: object
+                    type: object
+                  rolloutAfter:
+                    description: |-
+                      rolloutAfter performs a rollout of the entire cluster one component at a time,
+                      control plane first and then machine deployments.
+
+                      Deprecated: This field has no function and is going to be removed in the next apiVersion.
+                    format: date-time
+                    type: string
+                  variables:
+                    description: |-
+                      variables can be used to customize the Cluster through
+                      patches. They must comply to the corresponding
+                      VariableClasses defined in the ClusterClass.
+                    items:
+                      description: |-
+                        ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a
+                        Variable definition in the ClusterClass `status` variables.
+                      properties:
+                        definitionFrom:
+                          description: |-
+                            definitionFrom specifies where the definition of this Variable is from.
+
+                            Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                          maxLength: 256
+                          type: string
+                        name:
+                          description: name of the variable.
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        value:
+                          description: |-
+                            value of the variable.
+                            Note: the value will be validated against the schema of the corresponding ClusterClassVariable
+                            from the ClusterClass.
+                            Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a
+                            hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools,
+                            i.e. it is not possible to have no type field.
+                            Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111
+                          x-kubernetes-preserve-unknown-fields: true
+                      required:
+                      - name
+                      - value
+                      type: object
+                    maxItems: 1000
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  version:
+                    description: version is the Kubernetes version of the cluster.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  workers:
+                    description: |-
+                      workers encapsulates the different constructs that form the worker nodes
+                      for the cluster.
+                    properties:
+                      machineDeployments:
+                        description: machineDeployments is a list of machine deployments
+                          in the cluster.
+                        items:
+                          description: |-
+                            MachineDeploymentTopology specifies the different parameters for a set of worker nodes in the topology.
+                            This set of nodes is managed by a MachineDeployment object whose lifecycle is managed by the Cluster controller.
+                          properties:
+                            class:
+                              description: |-
+                                class is the name of the MachineDeploymentClass used to create the set of worker nodes.
+                                This should match one of the deployment classes defined in the ClusterClass object
+                                mentioned in the `Cluster.Spec.Class` field.
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            failureDomain:
+                              description: |-
+                                failureDomain is the failure domain the machines will be created in.
+                                Must match a key in the FailureDomains map stored on the cluster object.
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            machineHealthCheck:
+                              description: |-
+                                machineHealthCheck allows to enable, disable and override
+                                the MachineHealthCheck configuration in the ClusterClass for this MachineDeployment.
+                              properties:
+                                enable:
+                                  description: |-
+                                    enable controls if a MachineHealthCheck should be created for the target machines.
+
+                                    If false: No MachineHealthCheck will be created.
+
+                                    If not set(default): A MachineHealthCheck will be created if it is defined here or
+                                     in the associated ClusterClass. If no MachineHealthCheck is defined then none will be created.
+
+                                    If true: A MachineHealthCheck is guaranteed to be created. Cluster validation will
+                                    block if `enable` is true and no MachineHealthCheck definition is available.
+                                  type: boolean
+                                maxUnhealthy:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                                    Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
+                                    "selector" are not healthy.
+                                  x-kubernetes-int-or-string: true
+                                nodeStartupTimeout:
+                                  description: |-
+                                    nodeStartupTimeout allows to set the maximum time for MachineHealthCheck
+                                    to consider a Machine unhealthy if a corresponding Node isn't associated
+                                    through a `Spec.ProviderID` field.
+
+                                    The duration set in this field is compared to the greatest of:
+                                    - Cluster's infrastructure ready condition timestamp (if and when available)
+                                    - Control Plane's initialized condition timestamp (if and when available)
+                                    - Machine's infrastructure ready condition timestamp (if and when available)
+                                    - Machine's metadata creation timestamp
+
+                                    Defaults to 10 minutes.
+                                    If you wish to disable this feature, set the value explicitly to 0.
+                                  type: string
+                                remediationTemplate:
+                                  description: |-
+                                    remediationTemplate is a reference to a remediation template
+                                    provided by an infrastructure provider.
+
+                                    This field is completely optional, when filled, the MachineHealthCheck controller
+                                    creates a new object from the template referenced and hands off remediation of the machine to
+                                    a controller that lives outside of Cluster API.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                unhealthyConditions:
+                                  description: |-
+                                    unhealthyConditions contains a list of the conditions that determine
+                                    whether a node is considered unhealthy. The conditions are combined in a
+                                    logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                                  items:
+                                    description: |-
+                                      UnhealthyCondition represents a Node condition type and value with a timeout
+                                      specified as a duration.  When the named condition has been in the given
+                                      status for at least the timeout value, a node is considered unhealthy.
+                                    properties:
+                                      status:
+                                        description: status of the condition, one
+                                          of True, False, Unknown.
+                                        minLength: 1
+                                        type: string
+                                      timeout:
+                                        description: |-
+                                          timeout is the duration that a node must be in a given status for,
+                                          after which the node is considered unhealthy.
+                                          For example, with a value of "1h", the node must match the status
+                                          for at least 1 hour before being considered unhealthy.
+                                        type: string
+                                      type:
+                                        description: type of Node condition
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - status
+                                    - timeout
+                                    - type
+                                    type: object
+                                  maxItems: 100
+                                  type: array
+                                unhealthyRange:
+                                  description: |-
+                                    unhealthyRange specifies the range of unhealthy machines allowed.
+                                    Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
+                                    is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
+                                    Eg. "[3-5]" - This means that remediation will be allowed only when:
+                                    (a) there are at least 3 unhealthy machines (and)
+                                    (b) there are at most 5 unhealthy machines
+                                  maxLength: 32
+                                  minLength: 1
+                                  pattern: ^\[[0-9]+-[0-9]+\]$
+                                  type: string
+                              type: object
+                            metadata:
+                              description: |-
+                                metadata is the metadata applied to the MachineDeployment and the machines of the MachineDeployment.
+                                At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    annotations is an unstructured key value map stored with a resource that may be
+                                    set by external tools to store and retrieve arbitrary metadata. They are not
+                                    queryable and should be preserved when modifying objects.
+                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    labels is a map of string keys and values that can be used to organize and categorize
+                                    (scope and select) objects. May match selectors of replication controllers
+                                    and services.
+                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                  type: object
+                              type: object
+                            minReadySeconds:
+                              description: |-
+                                minReadySeconds is the minimum number of seconds for which a newly created machine should
+                                be ready.
+                                Defaults to 0 (machine will be considered available as soon as it
+                                is ready)
+                              format: int32
+                              type: integer
+                            name:
+                              description: |-
+                                name is the unique identifier for this MachineDeploymentTopology.
+                                The value is used with other unique identifiers to create a MachineDeployment's Name
+                                (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
+                                the values are hashed together.
+                              maxLength: 63
+                              minLength: 1
+                              type: string
+                            nodeDeletionTimeout:
+                              description: |-
+                                nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                                hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                                Defaults to 10 seconds.
+                              type: string
+                            nodeDrainTimeout:
+                              description: |-
+                                nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                                The default value is 0, meaning that the node can be drained without any time limitations.
+                                NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                              type: string
+                            nodeVolumeDetachTimeout:
+                              description: |-
+                                nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                                to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                              type: string
+                            readinessGates:
+                              description: |-
+                                readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                                This field can be used e.g. to instruct the machine controller to include in the computation for Machine's ready
+                                computation a condition, managed by an external controllers, reporting the status of special software/hardware installed on the Machine.
+
+                                If this field is not defined, readinessGates from the corresponding MachineDeploymentClass will be used, if any.
+
+                                NOTE: This field is considered only for computing v1beta2 conditions.
+                              items:
+                                description: MachineReadinessGate contains the type
+                                  of a Machine condition to be used as a readiness
+                                  gate.
+                                properties:
+                                  conditionType:
+                                    description: |-
+                                      conditionType refers to a condition with matching type in the Machine's condition list.
+                                      If the conditions doesn't exist, it will be treated as unknown.
+                                      Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                                    maxLength: 316
+                                    minLength: 1
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                  polarity:
+                                    description: |-
+                                      polarity of the conditionType specified in this readinessGate.
+                                      Valid values are Positive, Negative and omitted.
+                                      When omitted, the default behaviour will be Positive.
+                                      A positive polarity means that the condition should report a true status under normal conditions.
+                                      A negative polarity means that the condition should report a false status under normal conditions.
+                                    enum:
+                                    - Positive
+                                    - Negative
+                                    type: string
+                                required:
+                                - conditionType
+                                type: object
+                              maxItems: 32
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - conditionType
+                              x-kubernetes-list-type: map
+                            replicas:
+                              description: |-
+                                replicas is the number of worker nodes belonging to this set.
+                                If the value is nil, the MachineDeployment is created without the number of Replicas (defaulting to 1)
+                                and it's assumed that an external entity (like cluster autoscaler) is responsible for the management
+                                of this value.
+                              format: int32
+                              type: integer
+                            strategy:
+                              description: |-
+                                strategy is the deployment strategy to use to replace existing machines with
+                                new ones.
+                              properties:
+                                remediation:
+                                  description: |-
+                                    remediation controls the strategy of remediating unhealthy machines
+                                    and how remediating operations should occur during the lifecycle of the dependant MachineSets.
+                                  properties:
+                                    maxInFlight:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        maxInFlight determines how many in flight remediations should happen at the same time.
+
+                                        Remediation only happens on the MachineSet with the most current revision, while
+                                        older MachineSets (usually present during rollout operations) aren't allowed to remediate.
+
+                                        Note: In general (independent of remediations), unhealthy machines are always
+                                        prioritized during scale down operations over healthy ones.
+
+                                        MaxInFlight can be set to a fixed number or a percentage.
+                                        Example: when this is set to 20%, the MachineSet controller deletes at most 20% of
+                                        the desired replicas.
+
+                                        If not set, remediation is limited to all machines (bounded by replicas)
+                                        under the active MachineSet's management.
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                rollingUpdate:
+                                  description: |-
+                                    rollingUpdate is the rolling update config params. Present only if
+                                    MachineDeploymentStrategyType = RollingUpdate.
+                                  properties:
+                                    deletePolicy:
+                                      description: |-
+                                        deletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling.
+                                        Valid values are "Random, "Newest", "Oldest"
+                                        When no value is supplied, the default DeletePolicy of MachineSet is used
+                                      enum:
+                                      - Random
+                                      - Newest
+                                      - Oldest
+                                      type: string
+                                    maxSurge:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        maxSurge is the maximum number of machines that can be scheduled above the
+                                        desired number of machines.
+                                        Value can be an absolute number (ex: 5) or a percentage of
+                                        desired machines (ex: 10%).
+                                        This can not be 0 if MaxUnavailable is 0.
+                                        Absolute number is calculated from percentage by rounding up.
+                                        Defaults to 1.
+                                        Example: when this is set to 30%, the new MachineSet can be scaled
+                                        up immediately when the rolling update starts, such that the total
+                                        number of old and new machines do not exceed 130% of desired
+                                        machines. Once old machines have been killed, new MachineSet can
+                                        be scaled up further, ensuring that total number of machines running
+                                        at any time during the update is at most 130% of desired machines.
+                                      x-kubernetes-int-or-string: true
+                                    maxUnavailable:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        maxUnavailable is the maximum number of machines that can be unavailable during the update.
+                                        Value can be an absolute number (ex: 5) or a percentage of desired
+                                        machines (ex: 10%).
+                                        Absolute number is calculated from percentage by rounding down.
+                                        This can not be 0 if MaxSurge is 0.
+                                        Defaults to 0.
+                                        Example: when this is set to 30%, the old MachineSet can be scaled
+                                        down to 70% of desired machines immediately when the rolling update
+                                        starts. Once new machines are ready, old MachineSet can be scaled
+                                        down further, followed by scaling up the new MachineSet, ensuring
+                                        that the total number of machines available at all times
+                                        during the update is at least 70% of desired machines.
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                type:
+                                  description: |-
+                                    type of deployment. Allowed values are RollingUpdate and OnDelete.
+                                    The default is RollingUpdate.
+                                  enum:
+                                  - RollingUpdate
+                                  - OnDelete
+                                  type: string
+                              type: object
+                            variables:
+                              description: variables can be used to customize the
+                                MachineDeployment through patches.
+                              properties:
+                                overrides:
+                                  description: overrides can be used to override Cluster
+                                    level variables.
+                                  items:
+                                    description: |-
+                                      ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a
+                                      Variable definition in the ClusterClass `status` variables.
+                                    properties:
+                                      definitionFrom:
+                                        description: |-
+                                          definitionFrom specifies where the definition of this Variable is from.
+
+                                          Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                                        maxLength: 256
+                                        type: string
+                                      name:
+                                        description: name of the variable.
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                      value:
+                                        description: |-
+                                          value of the variable.
+                                          Note: the value will be validated against the schema of the corresponding ClusterClassVariable
+                                          from the ClusterClass.
+                                          Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a
+                                          hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools,
+                                          i.e. it is not possible to have no type field.
+                                          Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  maxItems: 1000
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                              type: object
+                          required:
+                          - class
+                          - name
+                          type: object
+                        maxItems: 2000
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      machinePools:
+                        description: machinePools is a list of machine pools in the
+                          cluster.
+                        items:
+                          description: |-
+                            MachinePoolTopology specifies the different parameters for a pool of worker nodes in the topology.
+                            This pool of nodes is managed by a MachinePool object whose lifecycle is managed by the Cluster controller.
+                          properties:
+                            class:
+                              description: |-
+                                class is the name of the MachinePoolClass used to create the pool of worker nodes.
+                                This should match one of the deployment classes defined in the ClusterClass object
+                                mentioned in the `Cluster.Spec.Class` field.
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            failureDomains:
+                              description: |-
+                                failureDomains is the list of failure domains the machine pool will be created in.
+                                Must match a key in the FailureDomains map stored on the cluster object.
+                              items:
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                              maxItems: 100
+                              type: array
+                            metadata:
+                              description: |-
+                                metadata is the metadata applied to the MachinePool.
+                                At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    annotations is an unstructured key value map stored with a resource that may be
+                                    set by external tools to store and retrieve arbitrary metadata. They are not
+                                    queryable and should be preserved when modifying objects.
+                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    labels is a map of string keys and values that can be used to organize and categorize
+                                    (scope and select) objects. May match selectors of replication controllers
+                                    and services.
+                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                  type: object
+                              type: object
+                            minReadySeconds:
+                              description: |-
+                                minReadySeconds is the minimum number of seconds for which a newly created machine pool should
+                                be ready.
+                                Defaults to 0 (machine will be considered available as soon as it
+                                is ready)
+                              format: int32
+                              type: integer
+                            name:
+                              description: |-
+                                name is the unique identifier for this MachinePoolTopology.
+                                The value is used with other unique identifiers to create a MachinePool's Name
+                                (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
+                                the values are hashed together.
+                              maxLength: 63
+                              minLength: 1
+                              type: string
+                            nodeDeletionTimeout:
+                              description: |-
+                                nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the MachinePool
+                                hosts after the MachinePool is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                                Defaults to 10 seconds.
+                              type: string
+                            nodeDrainTimeout:
+                              description: |-
+                                nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                                The default value is 0, meaning that the node can be drained without any time limitations.
+                                NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                              type: string
+                            nodeVolumeDetachTimeout:
+                              description: |-
+                                nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                                to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                              type: string
+                            replicas:
+                              description: |-
+                                replicas is the number of nodes belonging to this pool.
+                                If the value is nil, the MachinePool is created without the number of Replicas (defaulting to 1)
+                                and it's assumed that an external entity (like cluster autoscaler) is responsible for the management
+                                of this value.
+                              format: int32
+                              type: integer
+                            variables:
+                              description: variables can be used to customize the
+                                MachinePool through patches.
+                              properties:
+                                overrides:
+                                  description: overrides can be used to override Cluster
+                                    level variables.
+                                  items:
+                                    description: |-
+                                      ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a
+                                      Variable definition in the ClusterClass `status` variables.
+                                    properties:
+                                      definitionFrom:
+                                        description: |-
+                                          definitionFrom specifies where the definition of this Variable is from.
+
+                                          Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                                        maxLength: 256
+                                        type: string
+                                      name:
+                                        description: name of the variable.
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                      value:
+                                        description: |-
+                                          value of the variable.
+                                          Note: the value will be validated against the schema of the corresponding ClusterClassVariable
+                                          from the ClusterClass.
+                                          Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a
+                                          hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools,
+                                          i.e. it is not possible to have no type field.
+                                          Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  maxItems: 1000
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                              type: object
+                          required:
+                          - class
+                          - name
+                          type: object
+                        maxItems: 2000
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    type: object
+                required:
+                - class
+                - version
+                type: object
+            type: object
+          status:
+            description: status is the observed state of Cluster.
+            properties:
+              conditions:
+                description: conditions defines current service state of the cluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              controlPlaneReady:
+                description: |-
+                  controlPlaneReady denotes if the control plane became ready during initial provisioning
+                  to receive requests.
+                  NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+                  The value of this field is never updated after provisioning is completed. Please use conditions
+                  to check the operational state of the control plane.
+                type: boolean
+              failureDomains:
+                additionalProperties:
+                  description: |-
+                    FailureDomainSpec is the Schema for Cluster API failure domains.
+                    It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: controlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: failureDomains is a slice of failure domain objects synced
+                  from the infrastructure provider.
+                type: object
+              failureMessage:
+                description: |-
+                  failureMessage indicates that there is a fatal problem reconciling the
+                  state, and will be set to a descriptive error message.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                maxLength: 10240
+                minLength: 1
+                type: string
+              failureReason:
+                description: |-
+                  failureReason indicates that there is a fatal problem reconciling the
+                  state, and will be set to a token value suitable for
+                  programmatic interpretation.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: phase represents the current phase of cluster actuation.
+                enum:
+                - Pending
+                - Provisioning
+                - Provisioned
+                - Deleting
+                - Failed
+                - Unknown
+                type: string
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in Cluster's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a Cluster's current state.
+                      Known condition types are Available, InfrastructureReady, ControlPlaneInitialized, ControlPlaneAvailable, WorkersAvailable, MachinesReady
+                      MachinesUpToDate, RemoteConnectionProbe, ScalingUp, ScalingDown, Remediating, Deleting, Paused.
+                      Additionally, a TopologyReconciled condition will be added in case the Cluster is referencing a ClusterClass / defining a managed Topology.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                  controlPlane:
+                    description: controlPlane groups all the observations about Cluster's
+                      ControlPlane current state.
+                    properties:
+                      availableReplicas:
+                        description: availableReplicas is the total number of available
+                          control plane machines in this cluster. A machine is considered
+                          available when Machine's Available condition is true.
+                        format: int32
+                        type: integer
+                      desiredReplicas:
+                        description: desiredReplicas is the total number of desired
+                          control plane machines in this cluster.
+                        format: int32
+                        type: integer
+                      readyReplicas:
+                        description: readyReplicas is the total number of ready control
+                          plane machines in this cluster. A machine is considered
+                          ready when Machine's Ready condition is true.
+                        format: int32
+                        type: integer
+                      replicas:
+                        description: |-
+                          replicas is the total number of control plane machines in this cluster.
+                          NOTE: replicas also includes machines still being provisioned or being deleted.
+                        format: int32
+                        type: integer
+                      upToDateReplicas:
+                        description: upToDateReplicas is the number of up-to-date
+                          control plane machines in this cluster. A machine is considered
+                          up-to-date when Machine's UpToDate condition is true.
+                        format: int32
+                        type: integer
+                    type: object
+                  workers:
+                    description: workers groups all the observations about Cluster's
+                      Workers current state.
+                    properties:
+                      availableReplicas:
+                        description: availableReplicas is the total number of available
+                          worker machines in this cluster. A machine is considered
+                          available when Machine's Available condition is true.
+                        format: int32
+                        type: integer
+                      desiredReplicas:
+                        description: desiredReplicas is the total number of desired
+                          worker machines in this cluster.
+                        format: int32
+                        type: integer
+                      readyReplicas:
+                        description: readyReplicas is the total number of ready worker
+                          machines in this cluster. A machine is considered ready
+                          when Machine's Ready condition is true.
+                        format: int32
+                        type: integer
+                      replicas:
+                        description: |-
+                          replicas is the total number of worker machines in this cluster.
+                          NOTE: replicas also includes machines still being provisioned or being deleted.
+                        format: int32
+                        type: integer
+                      upToDateReplicas:
+                        description: upToDateReplicas is the number of up-to-date
+                          worker machines in this cluster. A machine is considered
+                          up-to-date when Machine's UpToDate condition is true.
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: extensionconfigs.runtime.cluster.x-k8s.io
+spec:
+  group: runtime.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ExtensionConfig
+    listKind: ExtensionConfigList
+    plural: extensionconfigs
+    shortNames:
+    - ext
+    singular: extensionconfig
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ExtensionConfig
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ExtensionConfig is the Schema for the ExtensionConfig API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of the ExtensionConfig.
+            properties:
+              clientConfig:
+                description: clientConfig defines how to communicate with the Extension
+                  server.
+                properties:
+                  caBundle:
+                    description: caBundle is a PEM encoded CA bundle which will be
+                      used to validate the Extension server's server certificate.
+                    format: byte
+                    maxLength: 51200
+                    minLength: 1
+                    type: string
+                  service:
+                    description: |-
+                      service is a reference to the Kubernetes service for the Extension server.
+                      Note: Exactly one of `url` or `service` must be specified.
+
+                      If the Extension server is running within a cluster, then you should use `service`.
+                    properties:
+                      name:
+                        description: name is the name of the service.
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the service.
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                      path:
+                        description: |-
+                          path is an optional URL path and if present may be any string permissible in
+                          a URL. If a path is set it will be used as prefix to the hook-specific path.
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                      port:
+                        description: |-
+                          port is the port on the service that's hosting the Extension server.
+                          Defaults to 443.
+                          Port should be a valid port number (1-65535, inclusive).
+                        format: int32
+                        type: integer
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  url:
+                    description: |-
+                      url gives the location of the Extension server, in standard URL form
+                      (`scheme://host:port/path`).
+                      Note: Exactly one of `url` or `service` must be specified.
+
+                      The scheme must be "https".
+
+                      The `host` should not refer to a service running in the cluster; use
+                      the `service` field instead.
+
+                      A path is optional, and if present may be any string permissible in
+                      a URL. If a path is set it will be used as prefix to the hook-specific path.
+
+                      Attempting to use a user or basic auth e.g. "user:password@" is not
+                      allowed. Fragments ("#...") and query parameters ("?...") are not
+                      allowed either.
+                    maxLength: 512
+                    minLength: 1
+                    type: string
+                type: object
+              namespaceSelector:
+                description: |-
+                  namespaceSelector decides whether to call the hook for an object based
+                  on whether the namespace for that object matches the selector.
+                  Defaults to the empty LabelSelector, which matches all objects.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              settings:
+                additionalProperties:
+                  type: string
+                description: |-
+                  settings defines key value pairs to be passed to all calls
+                  to all supported RuntimeExtensions.
+                  Note: Settings can be overridden on the ClusterClass.
+                type: object
+            required:
+            - clientConfig
+            type: object
+          status:
+            description: status is the current state of the ExtensionConfig
+            properties:
+              conditions:
+                description: conditions define the current service state of the ExtensionConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              handlers:
+                description: handlers defines the current ExtensionHandlers supported
+                  by an Extension.
+                items:
+                  description: ExtensionHandler specifies the details of a handler
+                    for a particular runtime hook registered by an Extension server.
+                  properties:
+                    failurePolicy:
+                      description: |-
+                        failurePolicy defines how failures in calls to the ExtensionHandler should be handled by a client.
+                        Defaults to Fail if not set.
+                      enum:
+                      - Ignore
+                      - Fail
+                      type: string
+                    name:
+                      description: name is the unique name of the ExtensionHandler.
+                      maxLength: 512
+                      minLength: 1
+                      type: string
+                    requestHook:
+                      description: requestHook defines the versioned runtime hook
+                        which this ExtensionHandler serves.
+                      properties:
+                        apiVersion:
+                          description: apiVersion is the group and version of the
+                            Hook.
+                          maxLength: 512
+                          minLength: 1
+                          type: string
+                        hook:
+                          description: hook is the name of the hook.
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                      required:
+                      - apiVersion
+                      - hook
+                      type: object
+                    timeoutSeconds:
+                      description: |-
+                        timeoutSeconds defines the timeout duration for client calls to the ExtensionHandler.
+                        Defaults to 10 is not set.
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  - requestHook
+                  type: object
+                maxItems: 512
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in ExtensionConfig's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a ExtensionConfig's current state.
+                      Known condition types are Discovered, Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: ipaddressclaims.ipam.cluster.x-k8s.io
+spec:
+  group: ipam.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: IPAddressClaim
+    listKind: IPAddressClaimList
+    plural: ipaddressclaims
+    singular: ipaddressclaim
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the pool to allocate an address from
+      jsonPath: .spec.poolRef.name
+      name: Pool Name
+      type: string
+    - description: Kind of the pool to allocate an address from
+      jsonPath: .spec.poolRef.kind
+      name: Pool Kind
+      type: string
+    - description: Time duration since creation of IPAdressClaim
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IPAddressClaim is the Schema for the ipaddressclaim API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of IPAddressClaim.
+            properties:
+              poolRef:
+                description: poolRef is a reference to the pool from which an IP address
+                  should be created.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - poolRef
+            type: object
+          status:
+            description: status is the observed state of IPAddressClaim.
+            properties:
+              addressRef:
+                description: addressRef is a reference to the address that was created
+                  for this claim.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              conditions:
+                description: conditions summarises the current state of the IPAddressClaim
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Name of the pool to allocate an address from
+      jsonPath: .spec.poolRef.name
+      name: Pool Name
+      type: string
+    - description: Kind of the pool to allocate an address from
+      jsonPath: .spec.poolRef.kind
+      name: Pool Kind
+      type: string
+    - description: Time duration since creation of IPAdressClaim
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: IPAddressClaim is the Schema for the ipaddressclaim API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of IPAddressClaim.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                maxLength: 63
+                minLength: 1
+                type: string
+              poolRef:
+                description: poolRef is a reference to the pool from which an IP address
+                  should be created.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - poolRef
+            type: object
+          status:
+            description: status is the observed state of IPAddressClaim.
+            properties:
+              addressRef:
+                description: addressRef is a reference to the address that was created
+                  for this claim.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              conditions:
+                description: conditions summarises the current state of the IPAddressClaim
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in IPAddressClaim's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: conditions represents the observations of a IPAddressClaim's
+                      current state.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: ipaddresses.ipam.cluster.x-k8s.io
+spec:
+  group: ipam.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: IPAddress
+    listKind: IPAddressList
+    plural: ipaddresses
+    singular: ipaddress
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Address
+      jsonPath: .spec.address
+      name: Address
+      type: string
+    - description: Name of the pool the address is from
+      jsonPath: .spec.poolRef.name
+      name: Pool Name
+      type: string
+    - description: Kind of the pool the address is from
+      jsonPath: .spec.poolRef.kind
+      name: Pool Kind
+      type: string
+    - description: Time duration since creation of IPAdress
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IPAddress is the Schema for the ipaddress API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of IPAddress.
+            properties:
+              address:
+                description: address is the IP address.
+                maxLength: 39
+                minLength: 1
+                type: string
+              claimRef:
+                description: claimRef is a reference to the claim this IPAddress was
+                  created for.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              gateway:
+                description: gateway is the network gateway of the network the address
+                  is from.
+                maxLength: 39
+                minLength: 1
+                type: string
+              poolRef:
+                description: poolRef is a reference to the pool that this IPAddress
+                  was created from.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              prefix:
+                description: prefix is the prefix of the address.
+                type: integer
+            required:
+            - address
+            - claimRef
+            - poolRef
+            - prefix
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: Address
+      jsonPath: .spec.address
+      name: Address
+      type: string
+    - description: Name of the pool the address is from
+      jsonPath: .spec.poolRef.name
+      name: Pool Name
+      type: string
+    - description: Kind of the pool the address is from
+      jsonPath: .spec.poolRef.kind
+      name: Pool Kind
+      type: string
+    - description: Time duration since creation of IPAdress
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: IPAddress is the Schema for the ipaddress API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of IPAddress.
+            properties:
+              address:
+                description: address is the IP address.
+                maxLength: 39
+                minLength: 1
+                type: string
+              claimRef:
+                description: claimRef is a reference to the claim this IPAddress was
+                  created for.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              gateway:
+                description: gateway is the network gateway of the network the address
+                  is from.
+                maxLength: 39
+                minLength: 1
+                type: string
+              poolRef:
+                description: poolRef is a reference to the pool that this IPAddress
+                  was created from.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              prefix:
+                description: prefix is the prefix of the address.
+                type: integer
+            required:
+            - address
+            - claimRef
+            - poolRef
+            - prefix
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.17.2
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: machinedeployments.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineDeployment
+    listKind: MachineDeploymentList
+    plural: machinedeployments
+    shortNames:
+    - md
+    singular: machinedeployment
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Total number of non-terminated machines targeted by this MachineDeployment
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this MachineDeployment
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this deployment
+        that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this MachineDeployment
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MachineDeployment is the Schema for the machinedeployments API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of MachineDeployment.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              minReadySeconds:
+                description: |-
+                  minReadySeconds is the minimum number of seconds for which a newly created machine should
+                  be ready.
+                  Defaults to 0 (machine will be considered available as soon as it
+                  is ready)
+                format: int32
+                type: integer
+              paused:
+                description: paused indicates that the deployment is paused.
+                type: boolean
+              progressDeadlineSeconds:
+                description: |-
+                  progressDeadlineSeconds is the maximum time in seconds for a deployment to make progress before it
+                  is considered to be failed. The deployment controller will continue to
+                  process failed deployments and a condition with a ProgressDeadlineExceeded
+                  reason will be surfaced in the deployment status. Note that progress will
+                  not be estimated during the time a deployment is paused. Defaults to 600s.
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  replicas is the number of desired machines. Defaults to 1.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: |-
+                  revisionHistoryLimit is the number of old MachineSets to retain to allow rollback.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                  Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the label selector for machines. Existing MachineSets whose machines are
+                  selected by this will be the ones affected by this deployment.
+                  It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              strategy:
+                description: |-
+                  strategy is the deployment strategy to use to replace existing machines with
+                  new ones.
+                properties:
+                  rollingUpdate:
+                    description: |-
+                      rollingUpdate is the rolling update config params. Present only if
+                      MachineDeploymentStrategyType = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          maxSurge is the maximum number of machines that can be scheduled above the
+                          desired number of machines.
+                          Value can be an absolute number (ex: 5) or a percentage of
+                          desired machines (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0.
+                          Absolute number is calculated from percentage by rounding up.
+                          Defaults to 1.
+                          Example: when this is set to 30%, the new MachineSet can be scaled
+                          up immediately when the rolling update starts, such that the total
+                          number of old and new machines do not exceed 130% of desired
+                          machines. Once old machines have been killed, new MachineSet can
+                          be scaled up further, ensuring that total number of machines running
+                          at any time during the update is at most 130% of desired machines.
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          maxUnavailable is the maximum number of machines that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired
+                          machines (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          This can not be 0 if MaxSurge is 0.
+                          Defaults to 0.
+                          Example: when this is set to 30%, the old MachineSet can be scaled
+                          down to 70% of desired machines immediately when the rolling update
+                          starts. Once new machines are ready, old MachineSet can be scaled
+                          down further, followed by scaling up the new MachineSet, ensuring
+                          that the total number of machines available at all times
+                          during the update is at least 70% of desired machines.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: |-
+                      type of deployment. Currently the only supported strategy is
+                      "RollingUpdate".
+                      Default is RollingUpdate.
+                    type: string
+                type: object
+              template:
+                description: template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: |-
+                      metadata is the standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      generateName:
+                        description: |-
+                          generateName is an optional prefix, used by the server, to generate a unique
+                          name ONLY IF the Name field has not been provided.
+                          If this field is used, the name returned to the client will be different
+                          than the name passed. This value will also be combined with a unique suffix.
+                          The provided value has the same validation rules as the Name field,
+                          and may be truncated by the length of the suffix required to make the value
+                          unique on the server.
+
+                          If this field is specified and the generated name exists, the server will
+                          NOT return a 409 - instead, it will either return 201 Created or 500 with Reason
+                          ServerTimeout indicating a unique name could not be found in the time allotted, and the client
+                          should retry (optionally after the time indicated in the Retry-After header).
+
+                          Applied only if Name is not specified.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                      name:
+                        description: |-
+                          name must be unique within a namespace. Is required when creating resources, although
+                          some resources may allow a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence and configuration
+                          definition.
+                          Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      namespace:
+                        description: |-
+                          namespace defines the space within each name must be unique. An empty namespace is
+                          equivalent to the "default" namespace, but "default" is the canonical representation.
+                          Not all objects are required to be scoped to a namespace - the value of this field for
+                          those objects will be empty.
+
+                          Must be a DNS_LABEL.
+                          Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/namespaces
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      ownerReferences:
+                        description: |-
+                          ownerReferences is the list of objects depended by this object. If ALL objects in the list have
+                          been deleted, this object will be garbage collected. If this object is managed by a controller,
+                          then an entry in this list will point to this controller, with the controller field set to true.
+                          There cannot be more than one managing controller.
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        items:
+                          description: |-
+                            OwnerReference contains enough information to let you identify an owning
+                            object. An owning object must be in the same namespace as the dependent, or
+                            be cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: |-
+                                If true, AND if the owner has the "foregroundDeletion" finalizer, then
+                                the owner cannot be deleted from the key-value store until this
+                                reference is removed.
+                                See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                                for how the garbage collector interacts with this field and enforces the foreground deletion.
+                                Defaults to false.
+                                To set this field, a user needs "delete" permission of the owner,
+                                otherwise 422 (Unprocessable Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: |-
+                                Kind of the referent.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                              type: string
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
+                              type: string
+                            uid:
+                              description: |-
+                                UID of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                    type: object
+                  spec:
+                    description: |-
+                      spec is the specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.Data without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          data:
+                            description: |-
+                              data contains the bootstrap data, such as cloud-init details scripts.
+                              If nil, the Machine should remain in the Pending state.
+
+                              Deprecated: Switch to DataSecretName.
+                            type: string
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            - template
+            type: object
+          status:
+            description: status is the observed state of MachineDeployment.
+            properties:
+              availableReplicas:
+                description: |-
+                  availableReplicas is the total number of available machines (ready for at least minReadySeconds)
+                  targeted by this deployment.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: observedGeneration is the generation observed by the
+                  deployment controller.
+                format: int64
+                type: integer
+              phase:
+                description: phase represents the current phase of a MachineDeployment
+                  (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+                type: string
+              readyReplicas:
+                description: readyReplicas is the total number of ready machines targeted
+                  by this deployment.
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  replicas is the total number of non-terminated machines targeted by this deployment
+                  (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the same as the label selector but in the string format to avoid introspection
+                  by clients. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                type: string
+              unavailableReplicas:
+                description: |-
+                  unavailableReplicas is the total number of unavailable machines targeted by this deployment.
+                  This is the total number of machines that are still required for
+                  the deployment to have 100% available capacity. They may either
+                  be machines that are running but not yet available or machines
+                  that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: |-
+                  updatedReplicas is the total number of non-terminated machines targeted by this deployment
+                  that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of MachineDeployment
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Total number of non-terminated machines targeted by this MachineDeployment
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this MachineDeployment
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this deployment
+        that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this MachineDeployment
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MachineDeployment is the Schema for the machinedeployments API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of MachineDeployment.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              minReadySeconds:
+                description: |-
+                  minReadySeconds is the minimum number of seconds for which a newly created machine should
+                  be ready.
+                  Defaults to 0 (machine will be considered available as soon as it
+                  is ready)
+                format: int32
+                type: integer
+              paused:
+                description: paused indicates that the deployment is paused.
+                type: boolean
+              progressDeadlineSeconds:
+                description: |-
+                  progressDeadlineSeconds is the maximum time in seconds for a deployment to make progress before it
+                  is considered to be failed. The deployment controller will continue to
+                  process failed deployments and a condition with a ProgressDeadlineExceeded
+                  reason will be surfaced in the deployment status. Note that progress will
+                  not be estimated during the time a deployment is paused. Defaults to 600s.
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: |-
+                  replicas is the number of desired machines. Defaults to 1.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: |-
+                  revisionHistoryLimit is the number of old MachineSets to retain to allow rollback.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                  Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the label selector for machines. Existing MachineSets whose machines are
+                  selected by this will be the ones affected by this deployment.
+                  It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              strategy:
+                description: |-
+                  strategy is the deployment strategy to use to replace existing machines with
+                  new ones.
+                properties:
+                  rollingUpdate:
+                    description: |-
+                      rollingUpdate is the rolling update config params. Present only if
+                      MachineDeploymentStrategyType = RollingUpdate.
+                    properties:
+                      deletePolicy:
+                        description: |-
+                          deletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling.
+                          Valid values are "Random, "Newest", "Oldest"
+                          When no value is supplied, the default DeletePolicy of MachineSet is used
+                        enum:
+                        - Random
+                        - Newest
+                        - Oldest
+                        type: string
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          maxSurge is the maximum number of machines that can be scheduled above the
+                          desired number of machines.
+                          Value can be an absolute number (ex: 5) or a percentage of
+                          desired machines (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0.
+                          Absolute number is calculated from percentage by rounding up.
+                          Defaults to 1.
+                          Example: when this is set to 30%, the new MachineSet can be scaled
+                          up immediately when the rolling update starts, such that the total
+                          number of old and new machines do not exceed 130% of desired
+                          machines. Once old machines have been killed, new MachineSet can
+                          be scaled up further, ensuring that total number of machines running
+                          at any time during the update is at most 130% of desired machines.
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          maxUnavailable is the maximum number of machines that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired
+                          machines (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          This can not be 0 if MaxSurge is 0.
+                          Defaults to 0.
+                          Example: when this is set to 30%, the old MachineSet can be scaled
+                          down to 70% of desired machines immediately when the rolling update
+                          starts. Once new machines are ready, old MachineSet can be scaled
+                          down further, followed by scaling up the new MachineSet, ensuring
+                          that the total number of machines available at all times
+                          during the update is at least 70% of desired machines.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: |-
+                      type of deployment.
+                      Default is RollingUpdate.
+                    enum:
+                    - RollingUpdate
+                    - OnDelete
+                    type: string
+                type: object
+              template:
+                description: template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: |-
+                      metadata is the standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      spec is the specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.DataSecretName without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            - template
+            type: object
+          status:
+            description: status is the observed state of MachineDeployment.
+            properties:
+              availableReplicas:
+                description: |-
+                  availableReplicas is the total number of available machines (ready for at least minReadySeconds)
+                  targeted by this deployment.
+                format: int32
+                type: integer
+              conditions:
+                description: conditions defines current service state of the MachineDeployment.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the generation observed by the
+                  deployment controller.
+                format: int64
+                type: integer
+              phase:
+                description: phase represents the current phase of a MachineDeployment
+                  (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+                type: string
+              readyReplicas:
+                description: readyReplicas is the total number of ready machines targeted
+                  by this deployment.
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  replicas is the total number of non-terminated machines targeted by this deployment
+                  (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the same as the label selector but in the string format to avoid introspection
+                  by clients. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                type: string
+              unavailableReplicas:
+                description: |-
+                  unavailableReplicas is the total number of unavailable machines targeted by this deployment.
+                  This is the total number of machines that are still required for
+                  the deployment to have 100% available capacity. They may either
+                  be machines that are running but not yet available or machines
+                  that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: |-
+                  updatedReplicas is the total number of non-terminated machines targeted by this deployment
+                  that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Total number of machines desired by this MachineDeployment
+      jsonPath: .spec.replicas
+      name: Desired
+      priority: 10
+      type: integer
+    - description: Total number of non-terminated machines targeted by this MachineDeployment
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this MachineDeployment
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this deployment
+        that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this MachineDeployment
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    - description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of MachineDeployment
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this MachineDeployment
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachineDeployment is the Schema for the machinedeployments API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of MachineDeployment.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                maxLength: 63
+                minLength: 1
+                type: string
+              machineNamingStrategy:
+                description: |-
+                  machineNamingStrategy allows changing the naming pattern used when creating Machines.
+                  Note: InfraMachines & BootstrapConfigs will use the same name as the corresponding Machines.
+                properties:
+                  template:
+                    description: |-
+                      template defines the template to use for generating the names of the
+                      Machine objects.
+                      If not defined, it will fallback to `{{ .machineSet.name }}-{{ .random }}`.
+                      If the generated name string exceeds 63 characters, it will be trimmed to
+                      58 characters and will
+                      get concatenated with a random suffix of length 5.
+                      Length of the template string must not exceed 256 characters.
+                      The template allows the following variables `.cluster.name`,
+                      `.machineSet.name` and `.random`.
+                      The variable `.cluster.name` retrieves the name of the cluster object
+                      that owns the Machines being created.
+                      The variable `.machineSet.name` retrieves the name of the MachineSet
+                      object that owns the Machines being created.
+                      The variable `.random` is substituted with random alphanumeric string,
+                      without vowels, of length 5. This variable is required part of the
+                      template. If not provided, validation will fail.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                type: object
+              minReadySeconds:
+                description: |-
+                  minReadySeconds is the minimum number of seconds for which a Node for a newly created machine should be ready before considering the replica available.
+                  Defaults to 0 (machine will be considered available as soon as the Node is ready)
+                format: int32
+                type: integer
+              paused:
+                description: paused indicates that the deployment is paused.
+                type: boolean
+              progressDeadlineSeconds:
+                description: |-
+                  progressDeadlineSeconds is the maximum time in seconds for a deployment to make progress before it
+                  is considered to be failed. The deployment controller will continue to
+                  process failed deployments and a condition with a ProgressDeadlineExceeded
+                  reason will be surfaced in the deployment status. Note that progress will
+                  not be estimated during the time a deployment is paused. Defaults to 600s.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/11470 for more details.
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  replicas is the number of desired machines.
+                  This is a pointer to distinguish between explicit zero and not specified.
+
+                  Defaults to:
+                  * if the Kubernetes autoscaler min size and max size annotations are set:
+                    - if it's a new MachineDeployment, use min size
+                    - if the replicas field of the old MachineDeployment is < min size, use min size
+                    - if the replicas field of the old MachineDeployment is > max size, use max size
+                    - if the replicas field of the old MachineDeployment is in the (min size, max size) range, keep the value from the oldMD
+                  * otherwise use 1
+                  Note: Defaulting will be run whenever the replicas field is not set:
+                  * A new MachineDeployment is created with replicas not set.
+                  * On an existing MachineDeployment the replicas field was first set and is now unset.
+                  Those cases are especially relevant for the following Kubernetes autoscaler use cases:
+                  * A new MachineDeployment is created and replicas should be managed by the autoscaler
+                  * An existing MachineDeployment which initially wasn't controlled by the autoscaler
+                    should be later controlled by the autoscaler
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: |-
+                  revisionHistoryLimit is the number of old MachineSets to retain to allow rollback.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                  Defaults to 1.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/10479 for more details.
+                format: int32
+                type: integer
+              rolloutAfter:
+                description: |-
+                  rolloutAfter is a field to indicate a rollout should be performed
+                  after the specified time even if no changes have been made to the
+                  MachineDeployment.
+                  Example: In the YAML the time can be specified in the RFC3339 format.
+                  To specify the rolloutAfter target as March 9, 2023, at 9 am UTC
+                  use "2023-03-09T09:00:00Z".
+                format: date-time
+                type: string
+              selector:
+                description: |-
+                  selector is the label selector for machines. Existing MachineSets whose machines are
+                  selected by this will be the ones affected by this deployment.
+                  It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              strategy:
+                description: |-
+                  strategy is the deployment strategy to use to replace existing machines with
+                  new ones.
+                properties:
+                  remediation:
+                    description: |-
+                      remediation controls the strategy of remediating unhealthy machines
+                      and how remediating operations should occur during the lifecycle of the dependant MachineSets.
+                    properties:
+                      maxInFlight:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          maxInFlight determines how many in flight remediations should happen at the same time.
+
+                          Remediation only happens on the MachineSet with the most current revision, while
+                          older MachineSets (usually present during rollout operations) aren't allowed to remediate.
+
+                          Note: In general (independent of remediations), unhealthy machines are always
+                          prioritized during scale down operations over healthy ones.
+
+                          MaxInFlight can be set to a fixed number or a percentage.
+                          Example: when this is set to 20%, the MachineSet controller deletes at most 20% of
+                          the desired replicas.
+
+                          If not set, remediation is limited to all machines (bounded by replicas)
+                          under the active MachineSet's management.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  rollingUpdate:
+                    description: |-
+                      rollingUpdate is the rolling update config params. Present only if
+                      MachineDeploymentStrategyType = RollingUpdate.
+                    properties:
+                      deletePolicy:
+                        description: |-
+                          deletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling.
+                          Valid values are "Random, "Newest", "Oldest"
+                          When no value is supplied, the default DeletePolicy of MachineSet is used
+                        enum:
+                        - Random
+                        - Newest
+                        - Oldest
+                        type: string
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          maxSurge is the maximum number of machines that can be scheduled above the
+                          desired number of machines.
+                          Value can be an absolute number (ex: 5) or a percentage of
+                          desired machines (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0.
+                          Absolute number is calculated from percentage by rounding up.
+                          Defaults to 1.
+                          Example: when this is set to 30%, the new MachineSet can be scaled
+                          up immediately when the rolling update starts, such that the total
+                          number of old and new machines do not exceed 130% of desired
+                          machines. Once old machines have been killed, new MachineSet can
+                          be scaled up further, ensuring that total number of machines running
+                          at any time during the update is at most 130% of desired machines.
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          maxUnavailable is the maximum number of machines that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired
+                          machines (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          This can not be 0 if MaxSurge is 0.
+                          Defaults to 0.
+                          Example: when this is set to 30%, the old MachineSet can be scaled
+                          down to 70% of desired machines immediately when the rolling update
+                          starts. Once new machines are ready, old MachineSet can be scaled
+                          down further, followed by scaling up the new MachineSet, ensuring
+                          that the total number of machines available at all times
+                          during the update is at least 70% of desired machines.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: |-
+                      type of deployment. Allowed values are RollingUpdate and OnDelete.
+                      The default is RollingUpdate.
+                    enum:
+                    - RollingUpdate
+                    - OnDelete
+                    type: string
+                type: object
+              template:
+                description: template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: |-
+                      metadata is the standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      spec is the specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.DataSecretName without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            maxLength: 253
+                            minLength: 0
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        maxLength: 256
+                        minLength: 1
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDeletionTimeout:
+                        description: |-
+                          nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                          hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                          Defaults to 10 seconds.
+                        type: string
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: |-
+                          nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                      readinessGates:
+                        description: |-
+                          readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                          This field can be used e.g. by Cluster API control plane providers to extend the semantic of the
+                          Ready condition for the Machine they control, like the kubeadm control provider adding ReadinessGates
+                          for the APIServerPodHealthy, SchedulerPodHealthy conditions, etc.
+
+                          Another example are external controllers, e.g. responsible to install special software/hardware on the Machines;
+                          they can include the status of those components with a new condition and add this condition to ReadinessGates.
+
+                          NOTE: This field is considered only for computing v1beta2 conditions.
+                          NOTE: In case readinessGates conditions start with the APIServer, ControllerManager, Scheduler prefix, and all those
+                          readiness gates condition are reporting the same message, when computing the Machine's Ready condition those
+                          readinessGates will be replaced by a single entry reporting "Control plane components: " + message.
+                          This helps to improve readability of conditions bubbling up to the Machine's owner resource / to the Cluster).
+                        items:
+                          description: MachineReadinessGate contains the type of a
+                            Machine condition to be used as a readiness gate.
+                          properties:
+                            conditionType:
+                              description: |-
+                                conditionType refers to a condition with matching type in the Machine's condition list.
+                                If the conditions doesn't exist, it will be treated as unknown.
+                                Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                              maxLength: 316
+                              minLength: 1
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                            polarity:
+                              description: |-
+                                polarity of the conditionType specified in this readinessGate.
+                                Valid values are Positive, Negative and omitted.
+                                When omitted, the default behaviour will be Positive.
+                                A positive polarity means that the condition should report a true status under normal conditions.
+                                A negative polarity means that the condition should report a false status under normal conditions.
+                              enum:
+                              - Positive
+                              - Negative
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - conditionType
+                        x-kubernetes-list-type: map
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        maxLength: 256
+                        minLength: 1
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            - template
+            type: object
+          status:
+            description: status is the observed state of MachineDeployment.
+            properties:
+              availableReplicas:
+                description: |-
+                  availableReplicas is the total number of available machines (ready for at least minReadySeconds)
+                  targeted by this deployment.
+                format: int32
+                type: integer
+              conditions:
+                description: conditions defines current service state of the MachineDeployment.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the generation observed by the
+                  deployment controller.
+                format: int64
+                type: integer
+              phase:
+                description: phase represents the current phase of a MachineDeployment
+                  (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+                enum:
+                - ScalingUp
+                - ScalingDown
+                - Running
+                - Failed
+                - Unknown
+                type: string
+              readyReplicas:
+                description: readyReplicas is the total number of ready machines targeted
+                  by this deployment.
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  replicas is the total number of non-terminated machines targeted by this deployment
+                  (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the same as the label selector but in the string format to avoid introspection
+                  by clients. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                maxLength: 4096
+                minLength: 1
+                type: string
+              unavailableReplicas:
+                description: |-
+                  unavailableReplicas is the total number of unavailable machines targeted by this deployment.
+                  This is the total number of machines that are still required for
+                  the deployment to have 100% available capacity. They may either
+                  be machines that are running but not yet available or machines
+                  that still have not been created.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: |-
+                  updatedReplicas is the total number of non-terminated machines targeted by this deployment
+                  that have the desired template spec.
+                format: int32
+                type: integer
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in MachineDeployment's status with the V1Beta2 version.
+                properties:
+                  availableReplicas:
+                    description: availableReplicas is the number of available replicas
+                      for this MachineDeployment. A machine is considered available
+                      when Machine's Available condition is true.
+                    format: int32
+                    type: integer
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a MachineDeployment's current state.
+                      Known condition types are Available, MachinesReady, MachinesUpToDate, ScalingUp, ScalingDown, Remediating, Deleting, Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                  readyReplicas:
+                    description: readyReplicas is the number of ready replicas for
+                      this MachineDeployment. A machine is considered ready when Machine's
+                      Ready condition is true.
+                    format: int32
+                    type: integer
+                  upToDateReplicas:
+                    description: upToDateReplicas is the number of up-to-date replicas
+                      targeted by this deployment. A machine is considered up-to-date
+                      when Machine's UpToDate condition is true.
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.17.2
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: machinedrainrules.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineDrainRule
+    listKind: MachineDrainRuleList
+    plural: machinedrainrules
+    singular: machinedrainrule
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Drain behavior
+      jsonPath: .spec.drain.behavior
+      name: Behavior
+      type: string
+    - description: Drain order
+      jsonPath: .spec.drain.order
+      name: Order
+      type: string
+    - description: Time duration since creation of the MachineDrainRule
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachineDrainRule is the Schema for the MachineDrainRule API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the spec of a MachineDrainRule.
+            properties:
+              drain:
+                description: drain configures if and how Pods are drained.
+                properties:
+                  behavior:
+                    description: |-
+                      behavior defines the drain behavior.
+                      Can be either "Drain", "Skip", or "WaitCompleted".
+                      "Drain" means that the Pods to which this MachineDrainRule applies will be drained.
+                      If behavior is set to "Drain" the order in which Pods are drained can be configured
+                      with the order field. When draining Pods of a Node the Pods will be grouped by order
+                      and one group after another will be drained (by increasing order). Cluster API will
+                      wait until all Pods of a group are terminated / removed from the Node before starting
+                      with the next group.
+                      "Skip" means that the Pods to which this MachineDrainRule applies will be skipped during drain.
+                      "WaitCompleted" means that the pods to which this MachineDrainRule applies will never be evicted
+                      and we wait for them to be completed, it is enforced that pods marked with this behavior always have Order=0.
+                    enum:
+                    - Drain
+                    - Skip
+                    - WaitCompleted
+                    type: string
+                  order:
+                    description: |-
+                      order defines the order in which Pods are drained.
+                      Pods with higher order are drained after Pods with lower order.
+                      order can only be set if behavior is set to "Drain".
+                      If order is not set, 0 will be used.
+                      Valid values for order are from -2147483648 to 2147483647 (inclusive).
+                    format: int32
+                    type: integer
+                required:
+                - behavior
+                type: object
+              machines:
+                description: |-
+                  machines defines to which Machines this MachineDrainRule should be applied.
+
+                  If machines is not set, the MachineDrainRule applies to all Machines in the Namespace.
+                  If machines contains multiple selectors, the results are ORed.
+                  Within a single Machine selector the results of selector and clusterSelector are ANDed.
+                  Machines will be selected from all Clusters in the Namespace unless otherwise
+                  restricted with the clusterSelector.
+
+                  Example: Selects control plane Machines in all Clusters or
+                           Machines with label "os" == "linux" in Clusters with label
+                           "stage" == "production".
+
+                   - selector:
+                       matchExpressions:
+                       - key: cluster.x-k8s.io/control-plane
+                         operator: Exists
+                   - selector:
+                       matchLabels:
+                         os: linux
+                     clusterSelector:
+                       matchExpressions:
+                       - key: stage
+                         operator: In
+                         values:
+                         - production
+                items:
+                  description: MachineDrainRuleMachineSelector defines to which Machines
+                    this MachineDrainRule should be applied.
+                  minProperties: 1
+                  properties:
+                    clusterSelector:
+                      description: |-
+                        clusterSelector is a label selector which selects Machines by the labels of
+                        their Clusters.
+                        This field follows standard label selector semantics; if not present or
+                        empty, it selects Machines of all Clusters.
+
+                        If selector is also set, then the selector as a whole selects
+                        Machines matching selector belonging to Clusters selected by clusterSelector.
+                        If selector is not set, it selects all Machines belonging to Clusters
+                        selected by clusterSelector.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    selector:
+                      description: |-
+                        selector is a label selector which selects Machines by their labels.
+                        This field follows standard label selector semantics; if not present or
+                        empty, it selects all Machines.
+
+                        If clusterSelector is also set, then the selector as a whole selects
+                        Machines matching selector belonging to Clusters selected by clusterSelector.
+                        If clusterSelector is not set, it selects all Machines matching selector in
+                        all Clusters.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                maxItems: 32
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: entries in machines must be unique
+                  rule: self.all(x, self.exists_one(y, x == y))
+              pods:
+                description: |-
+                  pods defines to which Pods this MachineDrainRule should be applied.
+
+                  If pods is not set, the MachineDrainRule applies to all Pods in all Namespaces.
+                  If pods contains multiple selectors, the results are ORed.
+                  Within a single Pod selector the results of selector and namespaceSelector are ANDed.
+                  Pods will be selected from all Namespaces unless otherwise
+                  restricted with the namespaceSelector.
+
+                  Example: Selects Pods with label "app" == "logging" in all Namespaces or
+                           Pods with label "app" == "prometheus" in the "monitoring"
+                           Namespace.
+
+                   - selector:
+                       matchExpressions:
+                       - key: app
+                         operator: In
+                         values:
+                         - logging
+                   - selector:
+                       matchLabels:
+                         app: prometheus
+                     namespaceSelector:
+                       matchLabels:
+                         kubernetes.io/metadata.name: monitoring
+                items:
+                  description: MachineDrainRulePodSelector defines to which Pods this
+                    MachineDrainRule should be applied.
+                  minProperties: 1
+                  properties:
+                    namespaceSelector:
+                      description: |-
+                        namespaceSelector is a label selector which selects Pods by the labels of
+                        their Namespaces.
+                        This field follows standard label selector semantics; if not present or
+                        empty, it selects Pods of all Namespaces.
+
+                        If selector is also set, then the selector as a whole selects
+                        Pods matching selector in Namespaces selected by namespaceSelector.
+                        If selector is not set, it selects all Pods in Namespaces selected by
+                        namespaceSelector.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    selector:
+                      description: |-
+                        selector is a label selector which selects Pods by their labels.
+                        This field follows standard label selector semantics; if not present or
+                        empty, it selects all Pods.
+
+                        If namespaceSelector is also set, then the selector as a whole selects
+                        Pods matching selector in Namespaces selected by namespaceSelector.
+                        If namespaceSelector is not set, it selects all Pods matching selector in
+                        all Namespaces.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                maxItems: 32
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: entries in pods must be unique
+                  rule: self.all(x, self.exists_one(y, x == y))
+            required:
+            - drain
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.17.2
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: machinehealthchecks.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineHealthCheck
+    listKind: MachineHealthCheckList
+    plural: machinehealthchecks
+    shortNames:
+    - mhc
+    - mhcs
+    singular: machinehealthcheck
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Maximum number of unhealthy machines allowed
+      jsonPath: .spec.maxUnhealthy
+      name: MaxUnhealthy
+      type: string
+    - description: Number of machines currently monitored
+      jsonPath: .status.expectedMachines
+      name: ExpectedMachines
+      type: integer
+    - description: Current observed healthy machines
+      jsonPath: .status.currentHealthy
+      name: CurrentHealthy
+      type: integer
+    deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MachineHealthCheck is the Schema for the machinehealthchecks API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of machine health check policy
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              maxUnhealthy:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                  Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
+                  "selector" are not healthy.
+                x-kubernetes-int-or-string: true
+              nodeStartupTimeout:
+                description: |-
+                  nodeStartupTimeout is the duration after which machines without a node will be considered to
+                  have failed and will be remediated.
+                type: string
+              remediationTemplate:
+                description: |-
+                  remediationTemplate is a reference to a remediation template
+                  provided by an infrastructure provider.
+
+                  This field is completely optional, when filled, the MachineHealthCheck controller
+                  creates a new object from the template referenced and hands off remediation of the machine to
+                  a controller that lives outside of Cluster API.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              selector:
+                description: selector is the label selector to match machines whose
+                  health will be exercised
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              unhealthyConditions:
+                description: |-
+                  unhealthyConditions contains a list of the conditions that determine
+                  whether a node is considered unhealthy.  The conditions are combined in a
+                  logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                items:
+                  description: |-
+                    UnhealthyCondition represents a Node condition type and value with a timeout
+                    specified as a duration.  When the named condition has been in the given
+                    status for at least the timeout value, a node is considered unhealthy.
+                  properties:
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      minLength: 1
+                      type: string
+                    timeout:
+                      description: |-
+                        timeout is the duration that a node must be in a given status for,
+                        after which the node is considered unhealthy.
+                        For example, with a value of "1h", the node must match the status
+                        for at least 1 hour before being considered unhealthy.
+                      type: string
+                    type:
+                      description: type of Node condition
+                      minLength: 1
+                      type: string
+                  required:
+                  - status
+                  - timeout
+                  - type
+                  type: object
+                minItems: 1
+                type: array
+            required:
+            - clusterName
+            - selector
+            - unhealthyConditions
+            type: object
+          status:
+            description: status is the most recently observed status of MachineHealthCheck
+              resource
+            properties:
+              conditions:
+                description: conditions defines current service state of the MachineHealthCheck.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentHealthy:
+                description: currentHealthy is the total number of healthy machines
+                  counted by this machine health check
+                format: int32
+                minimum: 0
+                type: integer
+              expectedMachines:
+                description: expectedMachines is the total number of machines counted
+                  by this machine health check
+                format: int32
+                minimum: 0
+                type: integer
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              remediationsAllowed:
+                description: |-
+                  remediationsAllowed is the number of further remediations allowed by this machine health check before
+                  maxUnhealthy short circuiting will be applied
+                format: int32
+                minimum: 0
+                type: integer
+              targets:
+                description: targets shows the current list of machines the machine
+                  health check is watching
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of MachineHealthCheck
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Maximum number of unhealthy machines allowed
+      jsonPath: .spec.maxUnhealthy
+      name: MaxUnhealthy
+      type: string
+    - description: Number of machines currently monitored
+      jsonPath: .status.expectedMachines
+      name: ExpectedMachines
+      type: integer
+    - description: Current observed healthy machines
+      jsonPath: .status.currentHealthy
+      name: CurrentHealthy
+      type: integer
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MachineHealthCheck is the Schema for the machinehealthchecks API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of machine health check policy
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              maxUnhealthy:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                  Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
+                  "selector" are not healthy.
+                x-kubernetes-int-or-string: true
+              nodeStartupTimeout:
+                description: |-
+                  nodeStartupTimeout is the duration after which machines without a node will be considered to
+                  have failed and will be remediated.
+                  If not set, this value is defaulted to 10 minutes.
+                  If you wish to disable this feature, set the value explicitly to 0.
+                type: string
+              remediationTemplate:
+                description: |-
+                  remediationTemplate is a reference to a remediation template
+                  provided by an infrastructure provider.
+
+                  This field is completely optional, when filled, the MachineHealthCheck controller
+                  creates a new object from the template referenced and hands off remediation of the machine to
+                  a controller that lives outside of Cluster API.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              selector:
+                description: selector is the label selector to match machines whose
+                  health will be exercised
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              unhealthyConditions:
+                description: |-
+                  unhealthyConditions contains a list of the conditions that determine
+                  whether a node is considered unhealthy.  The conditions are combined in a
+                  logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                items:
+                  description: |-
+                    UnhealthyCondition represents a Node condition type and value with a timeout
+                    specified as a duration.  When the named condition has been in the given
+                    status for at least the timeout value, a node is considered unhealthy.
+                  properties:
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      minLength: 1
+                      type: string
+                    timeout:
+                      description: |-
+                        timeout is the duration that a node must be in a given status for,
+                        after which the node is considered unhealthy.
+                        For example, with a value of "1h", the node must match the status
+                        for at least 1 hour before being considered unhealthy.
+                      type: string
+                    type:
+                      description: type of Node condition
+                      minLength: 1
+                      type: string
+                  required:
+                  - status
+                  - timeout
+                  - type
+                  type: object
+                minItems: 1
+                type: array
+              unhealthyRange:
+                description: |-
+                  unhealthyRange specifies the range of unhealthy machines allowed.
+                  Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
+                  is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
+                  Eg. "[3-5]" - This means that remediation will be allowed only when:
+                  (a) there are at least 3 unhealthy machines (and)
+                  (b) there are at most 5 unhealthy machines
+                pattern: ^\[[0-9]+-[0-9]+\]$
+                type: string
+            required:
+            - clusterName
+            - selector
+            - unhealthyConditions
+            type: object
+          status:
+            description: status is the most recently observed status of MachineHealthCheck
+              resource
+            properties:
+              conditions:
+                description: conditions defines current service state of the MachineHealthCheck.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentHealthy:
+                description: currentHealthy is the total number of healthy machines
+                  counted by this machine health check
+                format: int32
+                minimum: 0
+                type: integer
+              expectedMachines:
+                description: expectedMachines is the total number of machines counted
+                  by this machine health check
+                format: int32
+                minimum: 0
+                type: integer
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              remediationsAllowed:
+                description: |-
+                  remediationsAllowed is the number of further remediations allowed by this machine health check before
+                  maxUnhealthy short circuiting will be applied
+                format: int32
+                minimum: 0
+                type: integer
+              targets:
+                description: targets shows the current list of machines the machine
+                  health check is watching
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Number of machines currently monitored
+      jsonPath: .status.expectedMachines
+      name: ExpectedMachines
+      type: integer
+    - description: Maximum number of unhealthy machines allowed
+      jsonPath: .spec.maxUnhealthy
+      name: MaxUnhealthy
+      type: string
+    - description: Current observed healthy machines
+      jsonPath: .status.currentHealthy
+      name: CurrentHealthy
+      type: integer
+    - description: Time duration since creation of MachineHealthCheck
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachineHealthCheck is the Schema for the machinehealthchecks
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of machine health check policy
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                maxLength: 63
+                minLength: 1
+                type: string
+              maxUnhealthy:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                  Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
+                  "selector" are not healthy.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/10722 for more details.
+                x-kubernetes-int-or-string: true
+              nodeStartupTimeout:
+                description: |-
+                  nodeStartupTimeout allows to set the maximum time for MachineHealthCheck
+                  to consider a Machine unhealthy if a corresponding Node isn't associated
+                  through a `Spec.ProviderID` field.
+
+                  The duration set in this field is compared to the greatest of:
+                  - Cluster's infrastructure ready condition timestamp (if and when available)
+                  - Control Plane's initialized condition timestamp (if and when available)
+                  - Machine's infrastructure ready condition timestamp (if and when available)
+                  - Machine's metadata creation timestamp
+
+                  Defaults to 10 minutes.
+                  If you wish to disable this feature, set the value explicitly to 0.
+                type: string
+              remediationTemplate:
+                description: |-
+                  remediationTemplate is a reference to a remediation template
+                  provided by an infrastructure provider.
+
+                  This field is completely optional, when filled, the MachineHealthCheck controller
+                  creates a new object from the template referenced and hands off remediation of the machine to
+                  a controller that lives outside of Cluster API.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              selector:
+                description: selector is a label selector to match machines whose
+                  health will be exercised
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              unhealthyConditions:
+                description: |-
+                  unhealthyConditions contains a list of the conditions that determine
+                  whether a node is considered unhealthy.  The conditions are combined in a
+                  logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                items:
+                  description: |-
+                    UnhealthyCondition represents a Node condition type and value with a timeout
+                    specified as a duration.  When the named condition has been in the given
+                    status for at least the timeout value, a node is considered unhealthy.
+                  properties:
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      minLength: 1
+                      type: string
+                    timeout:
+                      description: |-
+                        timeout is the duration that a node must be in a given status for,
+                        after which the node is considered unhealthy.
+                        For example, with a value of "1h", the node must match the status
+                        for at least 1 hour before being considered unhealthy.
+                      type: string
+                    type:
+                      description: type of Node condition
+                      minLength: 1
+                      type: string
+                  required:
+                  - status
+                  - timeout
+                  - type
+                  type: object
+                maxItems: 100
+                type: array
+              unhealthyRange:
+                description: |-
+                  unhealthyRange specifies the range of unhealthy machines allowed.
+                  Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
+                  is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
+                  Eg. "[3-5]" - This means that remediation will be allowed only when:
+                  (a) there are at least 3 unhealthy machines (and)
+                  (b) there are at most 5 unhealthy machines
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/10722 for more details.
+                maxLength: 32
+                minLength: 1
+                pattern: ^\[[0-9]+-[0-9]+\]$
+                type: string
+            required:
+            - clusterName
+            - selector
+            type: object
+          status:
+            description: status is the most recently observed status of MachineHealthCheck
+              resource
+            properties:
+              conditions:
+                description: conditions defines current service state of the MachineHealthCheck.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentHealthy:
+                description: currentHealthy is the total number of healthy machines
+                  counted by this machine health check
+                format: int32
+                minimum: 0
+                type: integer
+              expectedMachines:
+                description: expectedMachines is the total number of machines counted
+                  by this machine health check
+                format: int32
+                minimum: 0
+                type: integer
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              remediationsAllowed:
+                description: |-
+                  remediationsAllowed is the number of further remediations allowed by this machine health check before
+                  maxUnhealthy short circuiting will be applied
+                format: int32
+                minimum: 0
+                type: integer
+              targets:
+                description: targets shows the current list of machines the machine
+                  health check is watching
+                items:
+                  maxLength: 253
+                  minLength: 1
+                  type: string
+                maxItems: 10000
+                type: array
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in MachineHealthCheck's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a MachineHealthCheck's current state.
+                      Known condition types are RemediationAllowed, Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.17.2
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: machinepools.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachinePool
+    listKind: MachinePoolList
+    plural: machinepools
+    shortNames:
+    - mp
+    singular: machinepool
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: MachinePool replicas count
+      jsonPath: .status.replicas
+      name: Replicas
+      type: string
+    - description: MachinePool status such as Terminating/Pending/Provisioning/Running/Failed
+        etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this MachinePool
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MachinePool is the Schema for the machinepools API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of MachinePool.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              failureDomains:
+                description: failureDomains is the list of failure domains this MachinePool
+                  should be attached to.
+                items:
+                  type: string
+                type: array
+              minReadySeconds:
+                description: |-
+                  minReadySeconds is the minimum number of seconds for which a newly created machine instances should
+                  be ready.
+                  Defaults to 0 (machine instance will be considered available as soon as it
+                  is ready)
+                format: int32
+                type: integer
+              providerIDList:
+                description: |-
+                  providerIDList are the identification IDs of machine instances provided by the provider.
+                  This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
+                items:
+                  type: string
+                type: array
+              replicas:
+                description: |-
+                  replicas is the number of desired machines. Defaults to 1.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              strategy:
+                description: |-
+                  strategy is the deployment strategy to use to replace existing machine instances with
+                  new ones.
+                properties:
+                  rollingUpdate:
+                    description: |-
+                      rollingUpdate is the rolling update config params. Present only if
+                      MachineDeploymentStrategyType = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          maxSurge is the maximum number of machines that can be scheduled above the
+                          desired number of machines.
+                          Value can be an absolute number (ex: 5) or a percentage of
+                          desired machines (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0.
+                          Absolute number is calculated from percentage by rounding up.
+                          Defaults to 1.
+                          Example: when this is set to 30%, the new MachineSet can be scaled
+                          up immediately when the rolling update starts, such that the total
+                          number of old and new machines do not exceed 130% of desired
+                          machines. Once old machines have been killed, new MachineSet can
+                          be scaled up further, ensuring that total number of machines running
+                          at any time during the update is at most 130% of desired machines.
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          maxUnavailable is the maximum number of machines that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired
+                          machines (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          This can not be 0 if MaxSurge is 0.
+                          Defaults to 0.
+                          Example: when this is set to 30%, the old MachineSet can be scaled
+                          down to 70% of desired machines immediately when the rolling update
+                          starts. Once new machines are ready, old MachineSet can be scaled
+                          down further, followed by scaling up the new MachineSet, ensuring
+                          that the total number of machines available at all times
+                          during the update is at least 70% of desired machines.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: |-
+                      type of deployment. Currently the only supported strategy is
+                      "RollingUpdate".
+                      Default is RollingUpdate.
+                    type: string
+                type: object
+              template:
+                description: template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: |-
+                      metadata is the standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      generateName:
+                        description: |-
+                          generateName is an optional prefix, used by the server, to generate a unique
+                          name ONLY IF the Name field has not been provided.
+                          If this field is used, the name returned to the client will be different
+                          than the name passed. This value will also be combined with a unique suffix.
+                          The provided value has the same validation rules as the Name field,
+                          and may be truncated by the length of the suffix required to make the value
+                          unique on the server.
+
+                          If this field is specified and the generated name exists, the server will
+                          NOT return a 409 - instead, it will either return 201 Created or 500 with Reason
+                          ServerTimeout indicating a unique name could not be found in the time allotted, and the client
+                          should retry (optionally after the time indicated in the Retry-After header).
+
+                          Applied only if Name is not specified.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                      name:
+                        description: |-
+                          name must be unique within a namespace. Is required when creating resources, although
+                          some resources may allow a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence and configuration
+                          definition.
+                          Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      namespace:
+                        description: |-
+                          namespace defines the space within each name must be unique. An empty namespace is
+                          equivalent to the "default" namespace, but "default" is the canonical representation.
+                          Not all objects are required to be scoped to a namespace - the value of this field for
+                          those objects will be empty.
+
+                          Must be a DNS_LABEL.
+                          Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/namespaces
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      ownerReferences:
+                        description: |-
+                          ownerReferences is the list of objects depended by this object. If ALL objects in the list have
+                          been deleted, this object will be garbage collected. If this object is managed by a controller,
+                          then an entry in this list will point to this controller, with the controller field set to true.
+                          There cannot be more than one managing controller.
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        items:
+                          description: |-
+                            OwnerReference contains enough information to let you identify an owning
+                            object. An owning object must be in the same namespace as the dependent, or
+                            be cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: |-
+                                If true, AND if the owner has the "foregroundDeletion" finalizer, then
+                                the owner cannot be deleted from the key-value store until this
+                                reference is removed.
+                                See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                                for how the garbage collector interacts with this field and enforces the foreground deletion.
+                                Defaults to false.
+                                To set this field, a user needs "delete" permission of the owner,
+                                otherwise 422 (Unprocessable Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: |-
+                                Kind of the referent.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                              type: string
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
+                              type: string
+                            uid:
+                              description: |-
+                                UID of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                    type: object
+                  spec:
+                    description: |-
+                      spec is the specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.Data without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          data:
+                            description: |-
+                              data contains the bootstrap data, such as cloud-init details scripts.
+                              If nil, the Machine should remain in the Pending state.
+
+                              Deprecated: Switch to DataSecretName.
+                            type: string
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - template
+            type: object
+          status:
+            description: status is the observed state of MachinePool.
+            properties:
+              availableReplicas:
+                description: availableReplicas is the number of available replicas
+                  (ready for at least minReadySeconds) for this MachinePool.
+                format: int32
+                type: integer
+              bootstrapReady:
+                description: bootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: conditions define the current service state of the MachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  failureMessage indicates that there is a problem reconciling the state,
+                  and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason indicates that there is a problem reconciling the state, and
+                  will be set to a token value suitable for programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              nodeRefs:
+                description: nodeRefs will point to the corresponding Nodes if it
+                  they exist.
+                items:
+                  description: ObjectReference contains enough information to let
+                    you inspect or modify the referred object.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: |-
+                  phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              readyReplicas:
+                description: readyReplicas is the number of ready replicas for this
+                  MachinePool. A machine is considered ready when the node has been
+                  created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: |-
+                  unavailableReplicas is the total number of unavailable machine instances targeted by this machine pool.
+                  This is the total number of machine instances that are still required for
+                  the machine pool to have 100% available capacity. They may either
+                  be machine instances that are running but not yet available or machine instances
+                  that still have not been created.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of MachinePool
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: MachinePool replicas count
+      jsonPath: .status.replicas
+      name: Replicas
+      type: string
+    - description: MachinePool status such as Terminating/Pending/Provisioning/Running/Failed
+        etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this MachinePool
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MachinePool is the Schema for the machinepools API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of MachinePool.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              failureDomains:
+                description: failureDomains is the list of failure domains this MachinePool
+                  should be attached to.
+                items:
+                  type: string
+                type: array
+              minReadySeconds:
+                description: |-
+                  minReadySeconds is the minimum number of seconds for which a newly created machine instances should
+                  be ready.
+                  Defaults to 0 (machine instance will be considered available as soon as it
+                  is ready)
+                format: int32
+                type: integer
+              providerIDList:
+                description: |-
+                  providerIDList are the identification IDs of machine instances provided by the provider.
+                  This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
+                items:
+                  type: string
+                type: array
+              replicas:
+                description: |-
+                  replicas is the number of desired machines. Defaults to 1.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              template:
+                description: template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: |-
+                      metadata is the standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      spec is the specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.DataSecretName without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - template
+            type: object
+          status:
+            description: status is the observed state of MachinePool.
+            properties:
+              availableReplicas:
+                description: availableReplicas is the number of available replicas
+                  (ready for at least minReadySeconds) for this MachinePool.
+                format: int32
+                type: integer
+              bootstrapReady:
+                description: bootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: conditions define the current service state of the MachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  failureMessage indicates that there is a problem reconciling the state,
+                  and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason indicates that there is a problem reconciling the state, and
+                  will be set to a token value suitable for programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              nodeRefs:
+                description: nodeRefs will point to the corresponding Nodes if it
+                  they exist.
+                items:
+                  description: ObjectReference contains enough information to let
+                    you inspect or modify the referred object.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: |-
+                  phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              readyReplicas:
+                description: readyReplicas is the number of ready replicas for this
+                  MachinePool. A machine is considered ready when the node has been
+                  created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: |-
+                  unavailableReplicas is the total number of unavailable machine instances targeted by this machine pool.
+                  This is the total number of machine instances that are still required for
+                  the machine pool to have 100% available capacity. They may either
+                  be machine instances that are running but not yet available or machine instances
+                  that still have not been created.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Total number of machines desired by this MachinePool
+      jsonPath: .spec.replicas
+      name: Desired
+      priority: 10
+      type: integer
+    - description: MachinePool replicas count
+      jsonPath: .status.replicas
+      name: Replicas
+      type: string
+    - description: MachinePool status such as Terminating/Pending/Provisioning/Running/Failed
+        etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of MachinePool
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this MachinePool
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachinePool is the Schema for the machinepools API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of MachinePool.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                maxLength: 63
+                minLength: 1
+                type: string
+              failureDomains:
+                description: failureDomains is the list of failure domains this MachinePool
+                  should be attached to.
+                items:
+                  maxLength: 256
+                  minLength: 1
+                  type: string
+                maxItems: 100
+                type: array
+              minReadySeconds:
+                description: |-
+                  minReadySeconds is the minimum number of seconds for which a newly created machine instances should
+                  be ready.
+                  Defaults to 0 (machine instance will be considered available as soon as it
+                  is ready)
+                format: int32
+                type: integer
+              providerIDList:
+                description: |-
+                  providerIDList are the identification IDs of machine instances provided by the provider.
+                  This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
+                items:
+                  maxLength: 512
+                  minLength: 1
+                  type: string
+                maxItems: 10000
+                type: array
+              replicas:
+                description: |-
+                  replicas is the number of desired machines. Defaults to 1.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              template:
+                description: template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: |-
+                      metadata is the standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      spec is the specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.DataSecretName without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            maxLength: 253
+                            minLength: 0
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        maxLength: 256
+                        minLength: 1
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDeletionTimeout:
+                        description: |-
+                          nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                          hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                          Defaults to 10 seconds.
+                        type: string
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: |-
+                          nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                      readinessGates:
+                        description: |-
+                          readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                          This field can be used e.g. by Cluster API control plane providers to extend the semantic of the
+                          Ready condition for the Machine they control, like the kubeadm control provider adding ReadinessGates
+                          for the APIServerPodHealthy, SchedulerPodHealthy conditions, etc.
+
+                          Another example are external controllers, e.g. responsible to install special software/hardware on the Machines;
+                          they can include the status of those components with a new condition and add this condition to ReadinessGates.
+
+                          NOTE: This field is considered only for computing v1beta2 conditions.
+                          NOTE: In case readinessGates conditions start with the APIServer, ControllerManager, Scheduler prefix, and all those
+                          readiness gates condition are reporting the same message, when computing the Machine's Ready condition those
+                          readinessGates will be replaced by a single entry reporting "Control plane components: " + message.
+                          This helps to improve readability of conditions bubbling up to the Machine's owner resource / to the Cluster).
+                        items:
+                          description: MachineReadinessGate contains the type of a
+                            Machine condition to be used as a readiness gate.
+                          properties:
+                            conditionType:
+                              description: |-
+                                conditionType refers to a condition with matching type in the Machine's condition list.
+                                If the conditions doesn't exist, it will be treated as unknown.
+                                Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                              maxLength: 316
+                              minLength: 1
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                            polarity:
+                              description: |-
+                                polarity of the conditionType specified in this readinessGate.
+                                Valid values are Positive, Negative and omitted.
+                                When omitted, the default behaviour will be Positive.
+                                A positive polarity means that the condition should report a true status under normal conditions.
+                                A negative polarity means that the condition should report a false status under normal conditions.
+                              enum:
+                              - Positive
+                              - Negative
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - conditionType
+                        x-kubernetes-list-type: map
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        maxLength: 256
+                        minLength: 1
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - template
+            type: object
+          status:
+            description: status is the observed state of MachinePool.
+            properties:
+              availableReplicas:
+                description: availableReplicas is the number of available replicas
+                  (ready for at least minReadySeconds) for this MachinePool.
+                format: int32
+                type: integer
+              bootstrapReady:
+                description: bootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: conditions define the current service state of the MachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  failureMessage indicates that there is a problem reconciling the state,
+                  and will be set to a descriptive error message.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                maxLength: 10240
+                minLength: 1
+                type: string
+              failureReason:
+                description: |-
+                  failureReason indicates that there is a problem reconciling the state, and
+                  will be set to a token value suitable for programmatic interpretation.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              nodeRefs:
+                description: nodeRefs will point to the corresponding Nodes if it
+                  they exist.
+                items:
+                  description: ObjectReference contains enough information to let
+                    you inspect or modify the referred object.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                maxItems: 10000
+                type: array
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: phase represents the current phase of cluster actuation.
+                enum:
+                - Pending
+                - Provisioning
+                - Provisioned
+                - Running
+                - ScalingUp
+                - ScalingDown
+                - Scaling
+                - Deleting
+                - Failed
+                - Unknown
+                type: string
+              readyReplicas:
+                description: readyReplicas is the number of ready replicas for this
+                  MachinePool. A machine is considered ready when the node has been
+                  created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: |-
+                  unavailableReplicas is the total number of unavailable machine instances targeted by this machine pool.
+                  This is the total number of machine instances that are still required for
+                  the machine pool to have 100% available capacity. They may either
+                  be machine instances that are running but not yet available or machine instances
+                  that still have not been created.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                format: int32
+                type: integer
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in MachinePool's status with the V1Beta2 version.
+                properties:
+                  availableReplicas:
+                    description: availableReplicas is the number of available replicas
+                      for this MachinePool. A machine is considered available when
+                      Machine's Available condition is true.
+                    format: int32
+                    type: integer
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a MachinePool's current state.
+                      Known condition types are Available, BootstrapConfigReady, InfrastructureReady, MachinesReady, MachinesUpToDate,
+                      ScalingUp, ScalingDown, Remediating, Deleting, Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                  readyReplicas:
+                    description: readyReplicas is the number of ready replicas for
+                      this MachinePool. A machine is considered ready when Machine's
+                      Ready condition is true.
+                    format: int32
+                    type: integer
+                  upToDateReplicas:
+                    description: upToDateReplicas is the number of up-to-date replicas
+                      targeted by this MachinePool. A machine is considered up-to-date
+                      when Machine's UpToDate condition is true.
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.17.2
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: machines.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: Machine
+    listKind: MachineList
+    plural: machines
+    shortNames:
+    - ma
+    singular: machine
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine status such as Terminating/Pending/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this Machine
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Node name associated with this machine
+      jsonPath: .status.nodeRef.name
+      name: NodeName
+      priority: 1
+      type: string
+    deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Machine is the Schema for the machines API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of Machine.
+            properties:
+              bootstrap:
+                description: |-
+                  bootstrap is a reference to a local struct which encapsulates
+                  fields to configure the Machine’s bootstrapping mechanism.
+                properties:
+                  configRef:
+                    description: |-
+                      configRef is a reference to a bootstrap provider-specific resource
+                      that holds configuration details. The reference is optional to
+                      allow users/operators to specify Bootstrap.Data without
+                      the need of a controller.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  data:
+                    description: |-
+                      data contains the bootstrap data, such as cloud-init details scripts.
+                      If nil, the Machine should remain in the Pending state.
+
+                      Deprecated: Switch to DataSecretName.
+                    type: string
+                  dataSecretName:
+                    description: |-
+                      dataSecretName is the name of the secret that stores the bootstrap data script.
+                      If nil, the Machine should remain in the Pending state.
+                    type: string
+                type: object
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              failureDomain:
+                description: |-
+                  failureDomain is the failure domain the machine will be created in.
+                  Must match a key in the FailureDomains map stored on the cluster object.
+                type: string
+              infrastructureRef:
+                description: |-
+                  infrastructureRef is a required reference to a custom resource
+                  offered by an infrastructure provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              nodeDrainTimeout:
+                description: |-
+                  nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                  The default value is 0, meaning that the node can be drained without any time limitations.
+                  NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                type: string
+              providerID:
+                description: |-
+                  providerID is the identification ID of the machine provided by the provider.
+                  This field must match the provider ID as seen on the node object corresponding to this machine.
+                  This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                  with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                  machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                  generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                  able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                  and then a comparison is done to find out unregistered machines and are marked for delete.
+                  This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                  be interfacing with cluster-api as generic provider.
+                type: string
+              version:
+                description: |-
+                  version defines the desired Kubernetes version.
+                  This field is meant to be optionally used by bootstrap providers.
+                type: string
+            required:
+            - bootstrap
+            - clusterName
+            - infrastructureRef
+            type: object
+          status:
+            description: status is the observed state of Machine.
+            properties:
+              addresses:
+                description: |-
+                  addresses is a list of addresses assigned to the machine.
+                  This field is copied from the infrastructure provider reference.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: address is the machine address.
+                      type: string
+                    type:
+                      description: type is the machine address type, one of Hostname,
+                        ExternalIP or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              bootstrapReady:
+                description: bootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: conditions defines current service state of the Machine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  failureMessage will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a succinct value suitable
+                  for machine interpretation.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              lastUpdated:
+                description: lastUpdated identifies when the phase of the Machine
+                  last transitioned.
+                format: date-time
+                type: string
+              nodeRef:
+                description: nodeRef will point to the corresponding Node if it exists.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: |-
+                  phase represents the current phase of machine actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              version:
+                description: |-
+                  version specifies the current version of Kubernetes running
+                  on the corresponding Node. This is meant to be a means of bubbling
+                  up status from the Node to the Machine.
+                  It is entirely optional, but useful for end-user UX if it’s present.
+                type: string
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of Machine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine status such as Terminating/Pending/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this Machine
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Node name associated with this machine
+      jsonPath: .status.nodeRef.name
+      name: NodeName
+      priority: 1
+      type: string
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Machine is the Schema for the machines API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of Machine.
+            properties:
+              bootstrap:
+                description: |-
+                  bootstrap is a reference to a local struct which encapsulates
+                  fields to configure the Machine’s bootstrapping mechanism.
+                properties:
+                  configRef:
+                    description: |-
+                      configRef is a reference to a bootstrap provider-specific resource
+                      that holds configuration details. The reference is optional to
+                      allow users/operators to specify Bootstrap.DataSecretName without
+                      the need of a controller.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  dataSecretName:
+                    description: |-
+                      dataSecretName is the name of the secret that stores the bootstrap data script.
+                      If nil, the Machine should remain in the Pending state.
+                    type: string
+                type: object
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              failureDomain:
+                description: |-
+                  failureDomain is the failure domain the machine will be created in.
+                  Must match a key in the FailureDomains map stored on the cluster object.
+                type: string
+              infrastructureRef:
+                description: |-
+                  infrastructureRef is a required reference to a custom resource
+                  offered by an infrastructure provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              nodeDrainTimeout:
+                description: |-
+                  nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                  The default value is 0, meaning that the node can be drained without any time limitations.
+                  NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                type: string
+              providerID:
+                description: |-
+                  providerID is the identification ID of the machine provided by the provider.
+                  This field must match the provider ID as seen on the node object corresponding to this machine.
+                  This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                  with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                  machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                  generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                  able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                  and then a comparison is done to find out unregistered machines and are marked for delete.
+                  This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                  be interfacing with cluster-api as generic provider.
+                type: string
+              version:
+                description: |-
+                  version defines the desired Kubernetes version.
+                  This field is meant to be optionally used by bootstrap providers.
+                type: string
+            required:
+            - bootstrap
+            - clusterName
+            - infrastructureRef
+            type: object
+          status:
+            description: status is the observed state of Machine.
+            properties:
+              addresses:
+                description: |-
+                  addresses is a list of addresses assigned to the machine.
+                  This field is copied from the infrastructure provider reference.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: address is the machine address.
+                      type: string
+                    type:
+                      description: type is the machine address type, one of Hostname,
+                        ExternalIP or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              bootstrapReady:
+                description: bootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: conditions defines current service state of the Machine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  failureMessage will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a succinct value suitable
+                  for machine interpretation.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              lastUpdated:
+                description: lastUpdated identifies when the phase of the Machine
+                  last transitioned.
+                format: date-time
+                type: string
+              nodeInfo:
+                description: |-
+                  nodeInfo is a set of ids/uuids to uniquely identify the node.
+                  More info: https://kubernetes.io/docs/concepts/nodes/node/#info
+                properties:
+                  architecture:
+                    description: The Architecture reported by the node
+                    type: string
+                  bootID:
+                    description: Boot ID reported by the node.
+                    type: string
+                  containerRuntimeVersion:
+                    description: ContainerRuntime Version reported by the node through
+                      runtime remote API (e.g. containerd://1.4.2).
+                    type: string
+                  kernelVersion:
+                    description: Kernel Version reported by the node from 'uname -r'
+                      (e.g. 3.16.0-0.bpo.4-amd64).
+                    type: string
+                  kubeProxyVersion:
+                    description: 'Deprecated: KubeProxy Version reported by the node.'
+                    type: string
+                  kubeletVersion:
+                    description: Kubelet Version reported by the node.
+                    type: string
+                  machineID:
+                    description: |-
+                      MachineID reported by the node. For unique machine identification
+                      in the cluster this field is preferred. Learn more from man(5)
+                      machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html
+                    type: string
+                  operatingSystem:
+                    description: The Operating System reported by the node
+                    type: string
+                  osImage:
+                    description: OS Image reported by the node from /etc/os-release
+                      (e.g. Debian GNU/Linux 7 (wheezy)).
+                    type: string
+                  systemUUID:
+                    description: |-
+                      SystemUUID reported by the node. For unique machine identification
+                      MachineID is preferred. This field is specific to Red Hat hosts
+                      https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid
+                    type: string
+                required:
+                - architecture
+                - bootID
+                - containerRuntimeVersion
+                - kernelVersion
+                - kubeProxyVersion
+                - kubeletVersion
+                - machineID
+                - operatingSystem
+                - osImage
+                - systemUUID
+                type: object
+              nodeRef:
+                description: nodeRef will point to the corresponding Node if it exists.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: |-
+                  phase represents the current phase of machine actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              version:
+                description: |-
+                  version specifies the current version of Kubernetes running
+                  on the corresponding Node. This is meant to be a means of bubbling
+                  up status from the Node to the Machine.
+                  It is entirely optional, but useful for end-user UX if it’s present.
+                type: string
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Node name associated with this machine
+      jsonPath: .status.nodeRef.name
+      name: NodeName
+      type: string
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine status such as Terminating/Pending/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of Machine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this Machine
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Machine is the Schema for the machines API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of Machine.
+            properties:
+              bootstrap:
+                description: |-
+                  bootstrap is a reference to a local struct which encapsulates
+                  fields to configure the Machine’s bootstrapping mechanism.
+                properties:
+                  configRef:
+                    description: |-
+                      configRef is a reference to a bootstrap provider-specific resource
+                      that holds configuration details. The reference is optional to
+                      allow users/operators to specify Bootstrap.DataSecretName without
+                      the need of a controller.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  dataSecretName:
+                    description: |-
+                      dataSecretName is the name of the secret that stores the bootstrap data script.
+                      If nil, the Machine should remain in the Pending state.
+                    maxLength: 253
+                    minLength: 0
+                    type: string
+                type: object
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                maxLength: 63
+                minLength: 1
+                type: string
+              failureDomain:
+                description: |-
+                  failureDomain is the failure domain the machine will be created in.
+                  Must match a key in the FailureDomains map stored on the cluster object.
+                maxLength: 256
+                minLength: 1
+                type: string
+              infrastructureRef:
+                description: |-
+                  infrastructureRef is a required reference to a custom resource
+                  offered by an infrastructure provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              nodeDeletionTimeout:
+                description: |-
+                  nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                  hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                  Defaults to 10 seconds.
+                type: string
+              nodeDrainTimeout:
+                description: |-
+                  nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                  The default value is 0, meaning that the node can be drained without any time limitations.
+                  NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                type: string
+              nodeVolumeDetachTimeout:
+                description: |-
+                  nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                  to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                type: string
+              providerID:
+                description: |-
+                  providerID is the identification ID of the machine provided by the provider.
+                  This field must match the provider ID as seen on the node object corresponding to this machine.
+                  This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                  with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                  machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                  generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                  able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                  and then a comparison is done to find out unregistered machines and are marked for delete.
+                  This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                  be interfacing with cluster-api as generic provider.
+                maxLength: 512
+                minLength: 1
+                type: string
+              readinessGates:
+                description: |-
+                  readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                  This field can be used e.g. by Cluster API control plane providers to extend the semantic of the
+                  Ready condition for the Machine they control, like the kubeadm control provider adding ReadinessGates
+                  for the APIServerPodHealthy, SchedulerPodHealthy conditions, etc.
+
+                  Another example are external controllers, e.g. responsible to install special software/hardware on the Machines;
+                  they can include the status of those components with a new condition and add this condition to ReadinessGates.
+
+                  NOTE: This field is considered only for computing v1beta2 conditions.
+                  NOTE: In case readinessGates conditions start with the APIServer, ControllerManager, Scheduler prefix, and all those
+                  readiness gates condition are reporting the same message, when computing the Machine's Ready condition those
+                  readinessGates will be replaced by a single entry reporting "Control plane components: " + message.
+                  This helps to improve readability of conditions bubbling up to the Machine's owner resource / to the Cluster).
+                items:
+                  description: MachineReadinessGate contains the type of a Machine
+                    condition to be used as a readiness gate.
+                  properties:
+                    conditionType:
+                      description: |-
+                        conditionType refers to a condition with matching type in the Machine's condition list.
+                        If the conditions doesn't exist, it will be treated as unknown.
+                        Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                      maxLength: 316
+                      minLength: 1
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                    polarity:
+                      description: |-
+                        polarity of the conditionType specified in this readinessGate.
+                        Valid values are Positive, Negative and omitted.
+                        When omitted, the default behaviour will be Positive.
+                        A positive polarity means that the condition should report a true status under normal conditions.
+                        A negative polarity means that the condition should report a false status under normal conditions.
+                      enum:
+                      - Positive
+                      - Negative
+                      type: string
+                  required:
+                  - conditionType
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - conditionType
+                x-kubernetes-list-type: map
+              version:
+                description: |-
+                  version defines the desired Kubernetes version.
+                  This field is meant to be optionally used by bootstrap providers.
+                maxLength: 256
+                minLength: 1
+                type: string
+            required:
+            - bootstrap
+            - clusterName
+            - infrastructureRef
+            type: object
+          status:
+            description: status is the observed state of Machine.
+            properties:
+              addresses:
+                description: |-
+                  addresses is a list of addresses assigned to the machine.
+                  This field is copied from the infrastructure provider reference.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: address is the machine address.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    type:
+                      description: type is the machine address type, one of Hostname,
+                        ExternalIP, InternalIP, ExternalDNS or InternalDNS.
+                      enum:
+                      - Hostname
+                      - ExternalIP
+                      - InternalIP
+                      - ExternalDNS
+                      - InternalDNS
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              bootstrapReady:
+                description: bootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              certificatesExpiryDate:
+                description: |-
+                  certificatesExpiryDate is the expiry date of the machine certificates.
+                  This value is only set for control plane machines.
+                format: date-time
+                type: string
+              conditions:
+                description: conditions defines current service state of the Machine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              deletion:
+                description: |-
+                  deletion contains information relating to removal of the Machine.
+                  Only present when the Machine has a deletionTimestamp and drain or wait for volume detach started.
+                properties:
+                  nodeDrainStartTime:
+                    description: |-
+                      nodeDrainStartTime is the time when the drain of the node started and is used to determine
+                      if the NodeDrainTimeout is exceeded.
+                      Only present when the Machine has a deletionTimestamp and draining the node had been started.
+                    format: date-time
+                    type: string
+                  waitForNodeVolumeDetachStartTime:
+                    description: |-
+                      waitForNodeVolumeDetachStartTime is the time when waiting for volume detachment started
+                      and is used to determine if the NodeVolumeDetachTimeout is exceeded.
+                      Detaching volumes from nodes is usually done by CSI implementations and the current state
+                      is observed from the node's `.Status.VolumesAttached` field.
+                      Only present when the Machine has a deletionTimestamp and waiting for volume detachments had been started.
+                    format: date-time
+                    type: string
+                type: object
+              failureMessage:
+                description: |-
+                  failureMessage will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                maxLength: 10240
+                minLength: 1
+                type: string
+              failureReason:
+                description: |-
+                  failureReason will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a succinct value suitable
+                  for machine interpretation.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              lastUpdated:
+                description: lastUpdated identifies when the phase of the Machine
+                  last transitioned.
+                format: date-time
+                type: string
+              nodeInfo:
+                description: |-
+                  nodeInfo is a set of ids/uuids to uniquely identify the node.
+                  More info: https://kubernetes.io/docs/concepts/nodes/node/#info
+                properties:
+                  architecture:
+                    description: The Architecture reported by the node
+                    type: string
+                  bootID:
+                    description: Boot ID reported by the node.
+                    type: string
+                  containerRuntimeVersion:
+                    description: ContainerRuntime Version reported by the node through
+                      runtime remote API (e.g. containerd://1.4.2).
+                    type: string
+                  kernelVersion:
+                    description: Kernel Version reported by the node from 'uname -r'
+                      (e.g. 3.16.0-0.bpo.4-amd64).
+                    type: string
+                  kubeProxyVersion:
+                    description: 'Deprecated: KubeProxy Version reported by the node.'
+                    type: string
+                  kubeletVersion:
+                    description: Kubelet Version reported by the node.
+                    type: string
+                  machineID:
+                    description: |-
+                      MachineID reported by the node. For unique machine identification
+                      in the cluster this field is preferred. Learn more from man(5)
+                      machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html
+                    type: string
+                  operatingSystem:
+                    description: The Operating System reported by the node
+                    type: string
+                  osImage:
+                    description: OS Image reported by the node from /etc/os-release
+                      (e.g. Debian GNU/Linux 7 (wheezy)).
+                    type: string
+                  systemUUID:
+                    description: |-
+                      SystemUUID reported by the node. For unique machine identification
+                      MachineID is preferred. This field is specific to Red Hat hosts
+                      https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid
+                    type: string
+                required:
+                - architecture
+                - bootID
+                - containerRuntimeVersion
+                - kernelVersion
+                - kubeProxyVersion
+                - kubeletVersion
+                - machineID
+                - operatingSystem
+                - osImage
+                - systemUUID
+                type: object
+              nodeRef:
+                description: nodeRef will point to the corresponding Node if it exists.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: phase represents the current phase of machine actuation.
+                enum:
+                - Pending
+                - Provisioning
+                - Provisioned
+                - Running
+                - Deleting
+                - Deleted
+                - Failed
+                - Unknown
+                type: string
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in Machine's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a Machine's current state.
+                      Known condition types are Available, Ready, UpToDate, BootstrapConfigReady, InfrastructureReady, NodeReady,
+                      NodeHealthy, Deleting, Paused.
+                      If a MachineHealthCheck is targeting this machine, also HealthCheckSucceeded, OwnerRemediated conditions are added.
+                      Additionally control plane Machines controlled by KubeadmControlPlane will have following additional conditions:
+                      APIServerPodHealthy, ControllerManagerPodHealthy, SchedulerPodHealthy, EtcdPodHealthy, EtcdMemberHealthy.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.17.2
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: machinesets.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineSet
+    listKind: MachineSetList
+    plural: machinesets
+    shortNames:
+    - ms
+    singular: machineset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Total number of non-terminated machines targeted by this machineset
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of available machines (ready for at least minReadySeconds)
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - description: Total number of ready machines targeted by this machineset.
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MachineSet is the Schema for the machinesets API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of MachineSet.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              deletePolicy:
+                description: |-
+                  deletePolicy defines the policy used to identify nodes to delete when downscaling.
+                  Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+                enum:
+                - Random
+                - Newest
+                - Oldest
+                type: string
+              minReadySeconds:
+                description: |-
+                  minReadySeconds is the minimum number of seconds for which a newly created machine should be ready.
+                  Defaults to 0 (machine will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  replicas is the number of desired replicas.
+                  This is a pointer to distinguish between explicit zero and unspecified.
+                  Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is a label query over machines that should match the replica count.
+                  Label keys and values that must match in order to be controlled by this MachineSet.
+                  It must match the machine template's labels.
+                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              template:
+                description: |-
+                  template is the object that describes the machine that will be created if
+                  insufficient replicas are detected.
+                  Object references to custom resources are treated as templates.
+                properties:
+                  metadata:
+                    description: |-
+                      metadata is the standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      generateName:
+                        description: |-
+                          generateName is an optional prefix, used by the server, to generate a unique
+                          name ONLY IF the Name field has not been provided.
+                          If this field is used, the name returned to the client will be different
+                          than the name passed. This value will also be combined with a unique suffix.
+                          The provided value has the same validation rules as the Name field,
+                          and may be truncated by the length of the suffix required to make the value
+                          unique on the server.
+
+                          If this field is specified and the generated name exists, the server will
+                          NOT return a 409 - instead, it will either return 201 Created or 500 with Reason
+                          ServerTimeout indicating a unique name could not be found in the time allotted, and the client
+                          should retry (optionally after the time indicated in the Retry-After header).
+
+                          Applied only if Name is not specified.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                      name:
+                        description: |-
+                          name must be unique within a namespace. Is required when creating resources, although
+                          some resources may allow a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence and configuration
+                          definition.
+                          Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      namespace:
+                        description: |-
+                          namespace defines the space within each name must be unique. An empty namespace is
+                          equivalent to the "default" namespace, but "default" is the canonical representation.
+                          Not all objects are required to be scoped to a namespace - the value of this field for
+                          those objects will be empty.
+
+                          Must be a DNS_LABEL.
+                          Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/namespaces
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      ownerReferences:
+                        description: |-
+                          ownerReferences is the list of objects depended by this object. If ALL objects in the list have
+                          been deleted, this object will be garbage collected. If this object is managed by a controller,
+                          then an entry in this list will point to this controller, with the controller field set to true.
+                          There cannot be more than one managing controller.
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        items:
+                          description: |-
+                            OwnerReference contains enough information to let you identify an owning
+                            object. An owning object must be in the same namespace as the dependent, or
+                            be cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: |-
+                                If true, AND if the owner has the "foregroundDeletion" finalizer, then
+                                the owner cannot be deleted from the key-value store until this
+                                reference is removed.
+                                See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                                for how the garbage collector interacts with this field and enforces the foreground deletion.
+                                Defaults to false.
+                                To set this field, a user needs "delete" permission of the owner,
+                                otherwise 422 (Unprocessable Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: |-
+                                Kind of the referent.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                              type: string
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
+                              type: string
+                            uid:
+                              description: |-
+                                UID of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                    type: object
+                  spec:
+                    description: |-
+                      spec is the specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.Data without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          data:
+                            description: |-
+                              data contains the bootstrap data, such as cloud-init details scripts.
+                              If nil, the Machine should remain in the Pending state.
+
+                              Deprecated: Switch to DataSecretName.
+                            type: string
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            type: object
+          status:
+            description: status is the observed state of MachineSet.
+            properties:
+              availableReplicas:
+                description: availableReplicas is the number of available replicas
+                  (ready for at least minReadySeconds) for this MachineSet.
+                format: int32
+                type: integer
+              failureMessage:
+                description: |-
+                  failureMessage will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a more verbose string suitable
+                  for logging and human consumption.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a succinct value suitable
+                  for machine interpretation.
+
+                  In the event that there is a terminal problem reconciling the
+                  replicas, both FailureReason and FailureMessage will be set. FailureReason
+                  will be populated with a succinct value suitable for machine
+                  interpretation, while FailureMessage will contain a more verbose
+                  string suitable for logging and human consumption.
+
+                  These fields should not be set for transitive errors that a
+                  controller faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the MachineTemplate's spec or the configuration of
+                  the machine controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the machine controller, or the
+                  responsible machine controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the MachineSet object and/or logged in the
+                  controller's output.
+                type: string
+              fullyLabeledReplicas:
+                description: fullyLabeledReplicas is the number of replicas that have
+                  labels matching the labels of the machine template of the MachineSet.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: observedGeneration reflects the generation of the most
+                  recently observed MachineSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas is the number of ready replicas for this
+                  MachineSet. A machine is considered ready when the node has been
+                  created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the same as the label selector but in the string format to avoid introspection
+                  by clients. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                type: string
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of MachineSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Total number of non-terminated machines targeted by this machineset
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of available machines (ready for at least minReadySeconds)
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - description: Total number of ready machines targeted by this machineset.
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MachineSet is the Schema for the machinesets API.
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of MachineSet.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              deletePolicy:
+                description: |-
+                  deletePolicy defines the policy used to identify nodes to delete when downscaling.
+                  Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+                enum:
+                - Random
+                - Newest
+                - Oldest
+                type: string
+              minReadySeconds:
+                description: |-
+                  minReadySeconds is the minimum number of seconds for which a newly created machine should be ready.
+                  Defaults to 0 (machine will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: |-
+                  replicas is the number of desired replicas.
+                  This is a pointer to distinguish between explicit zero and unspecified.
+                  Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is a label query over machines that should match the replica count.
+                  Label keys and values that must match in order to be controlled by this MachineSet.
+                  It must match the machine template's labels.
+                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              template:
+                description: |-
+                  template is the object that describes the machine that will be created if
+                  insufficient replicas are detected.
+                  Object references to custom resources are treated as templates.
+                properties:
+                  metadata:
+                    description: |-
+                      metadata is the standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      spec is the specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.DataSecretName without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            type: object
+          status:
+            description: status is the observed state of MachineSet.
+            properties:
+              availableReplicas:
+                description: availableReplicas is the number of available replicas
+                  (ready for at least minReadySeconds) for this MachineSet.
+                format: int32
+                type: integer
+              conditions:
+                description: conditions defines current service state of the MachineSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  failureMessage will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a more verbose string suitable
+                  for logging and human consumption.
+                type: string
+              failureReason:
+                description: |-
+                  failureReason will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a succinct value suitable
+                  for machine interpretation.
+
+                  In the event that there is a terminal problem reconciling the
+                  replicas, both FailureReason and FailureMessage will be set. FailureReason
+                  will be populated with a succinct value suitable for machine
+                  interpretation, while FailureMessage will contain a more verbose
+                  string suitable for logging and human consumption.
+
+                  These fields should not be set for transitive errors that a
+                  controller faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the MachineTemplate's spec or the configuration of
+                  the machine controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the machine controller, or the
+                  responsible machine controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the MachineSet object and/or logged in the
+                  controller's output.
+                type: string
+              fullyLabeledReplicas:
+                description: fullyLabeledReplicas is the number of replicas that have
+                  labels matching the labels of the machine template of the MachineSet.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: observedGeneration reflects the generation of the most
+                  recently observed MachineSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas is the number of ready replicas for this
+                  MachineSet. A machine is considered ready when the node has been
+                  created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the same as the label selector but in the string format to avoid introspection
+                  by clients. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                type: string
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Total number of machines desired by this machineset
+      jsonPath: .spec.replicas
+      name: Desired
+      priority: 10
+      type: integer
+    - description: Total number of non-terminated machines targeted by this machineset
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this machineset.
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of available machines (ready for at least minReadySeconds)
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - description: Time duration since creation of MachineSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this MachineSet
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachineSet is the Schema for the machinesets API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of MachineSet.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                maxLength: 63
+                minLength: 1
+                type: string
+              deletePolicy:
+                description: |-
+                  deletePolicy defines the policy used to identify nodes to delete when downscaling.
+                  Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+                enum:
+                - Random
+                - Newest
+                - Oldest
+                type: string
+              machineNamingStrategy:
+                description: |-
+                  machineNamingStrategy allows changing the naming pattern used when creating Machines.
+                  Note: InfraMachines & BootstrapConfigs will use the same name as the corresponding Machines.
+                properties:
+                  template:
+                    description: |-
+                      template defines the template to use for generating the names of the
+                      Machine objects.
+                      If not defined, it will fallback to `{{ .machineSet.name }}-{{ .random }}`.
+                      If the generated name string exceeds 63 characters, it will be trimmed to
+                      58 characters and will
+                      get concatenated with a random suffix of length 5.
+                      Length of the template string must not exceed 256 characters.
+                      The template allows the following variables `.cluster.name`,
+                      `.machineSet.name` and `.random`.
+                      The variable `.cluster.name` retrieves the name of the cluster object
+                      that owns the Machines being created.
+                      The variable `.machineSet.name` retrieves the name of the MachineSet
+                      object that owns the Machines being created.
+                      The variable `.random` is substituted with random alphanumeric string,
+                      without vowels, of length 5. This variable is required part of the
+                      template. If not provided, validation will fail.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                type: object
+              minReadySeconds:
+                description: |-
+                  minReadySeconds is the minimum number of seconds for which a Node for a newly created machine should be ready before considering the replica available.
+                  Defaults to 0 (machine will be considered available as soon as the Node is ready)
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  replicas is the number of desired replicas.
+                  This is a pointer to distinguish between explicit zero and unspecified.
+
+                  Defaults to:
+                  * if the Kubernetes autoscaler min size and max size annotations are set:
+                    - if it's a new MachineSet, use min size
+                    - if the replicas field of the old MachineSet is < min size, use min size
+                    - if the replicas field of the old MachineSet is > max size, use max size
+                    - if the replicas field of the old MachineSet is in the (min size, max size) range, keep the value from the oldMS
+                  * otherwise use 1
+                  Note: Defaulting will be run whenever the replicas field is not set:
+                  * A new MachineSet is created with replicas not set.
+                  * On an existing MachineSet the replicas field was first set and is now unset.
+                  Those cases are especially relevant for the following Kubernetes autoscaler use cases:
+                  * A new MachineSet is created and replicas should be managed by the autoscaler
+                  * An existing MachineSet which initially wasn't controlled by the autoscaler
+                    should be later controlled by the autoscaler
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is a label query over machines that should match the replica count.
+                  Label keys and values that must match in order to be controlled by this MachineSet.
+                  It must match the machine template's labels.
+                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              template:
+                description: |-
+                  template is the object that describes the machine that will be created if
+                  insufficient replicas are detected.
+                  Object references to custom resources are treated as templates.
+                properties:
+                  metadata:
+                    description: |-
+                      metadata is the standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      spec is the specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.DataSecretName without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            maxLength: 253
+                            minLength: 0
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        maxLength: 256
+                        minLength: 1
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDeletionTimeout:
+                        description: |-
+                          nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                          hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                          Defaults to 10 seconds.
+                        type: string
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: |-
+                          nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                      readinessGates:
+                        description: |-
+                          readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                          This field can be used e.g. by Cluster API control plane providers to extend the semantic of the
+                          Ready condition for the Machine they control, like the kubeadm control provider adding ReadinessGates
+                          for the APIServerPodHealthy, SchedulerPodHealthy conditions, etc.
+
+                          Another example are external controllers, e.g. responsible to install special software/hardware on the Machines;
+                          they can include the status of those components with a new condition and add this condition to ReadinessGates.
+
+                          NOTE: This field is considered only for computing v1beta2 conditions.
+                          NOTE: In case readinessGates conditions start with the APIServer, ControllerManager, Scheduler prefix, and all those
+                          readiness gates condition are reporting the same message, when computing the Machine's Ready condition those
+                          readinessGates will be replaced by a single entry reporting "Control plane components: " + message.
+                          This helps to improve readability of conditions bubbling up to the Machine's owner resource / to the Cluster).
+                        items:
+                          description: MachineReadinessGate contains the type of a
+                            Machine condition to be used as a readiness gate.
+                          properties:
+                            conditionType:
+                              description: |-
+                                conditionType refers to a condition with matching type in the Machine's condition list.
+                                If the conditions doesn't exist, it will be treated as unknown.
+                                Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                              maxLength: 316
+                              minLength: 1
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                            polarity:
+                              description: |-
+                                polarity of the conditionType specified in this readinessGate.
+                                Valid values are Positive, Negative and omitted.
+                                When omitted, the default behaviour will be Positive.
+                                A positive polarity means that the condition should report a true status under normal conditions.
+                                A negative polarity means that the condition should report a false status under normal conditions.
+                              enum:
+                              - Positive
+                              - Negative
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - conditionType
+                        x-kubernetes-list-type: map
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        maxLength: 256
+                        minLength: 1
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            type: object
+          status:
+            description: status is the observed state of MachineSet.
+            properties:
+              availableReplicas:
+                description: availableReplicas is the number of available replicas
+                  (ready for at least minReadySeconds) for this MachineSet.
+                format: int32
+                type: integer
+              conditions:
+                description: conditions defines current service state of the MachineSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  failureMessage will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                maxLength: 10240
+                minLength: 1
+                type: string
+              failureReason:
+                description: |-
+                  failureReason will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a succinct value suitable
+                  for machine interpretation.
+
+                  In the event that there is a terminal problem reconciling the
+                  replicas, both FailureReason and FailureMessage will be set. FailureReason
+                  will be populated with a succinct value suitable for machine
+                  interpretation, while FailureMessage will contain a more verbose
+                  string suitable for logging and human consumption.
+
+                  These fields should not be set for transitive errors that a
+                  controller faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the MachineTemplate's spec or the configuration of
+                  the machine controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the machine controller, or the
+                  responsible machine controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the MachineSet object and/or logged in the
+                  controller's output.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              fullyLabeledReplicas:
+                description: |-
+                  fullyLabeledReplicas is the number of replicas that have labels matching the labels of the machine template of the MachineSet.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: observedGeneration reflects the generation of the most
+                  recently observed MachineSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas is the number of ready replicas for this
+                  MachineSet. A machine is considered ready when the node has been
+                  created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the same as the label selector but in the string format to avoid introspection
+                  by clients. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                maxLength: 4096
+                minLength: 1
+                type: string
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in MachineSet's status with the V1Beta2 version.
+                properties:
+                  availableReplicas:
+                    description: availableReplicas is the number of available replicas
+                      for this MachineSet. A machine is considered available when
+                      Machine's Available condition is true.
+                    format: int32
+                    type: integer
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a MachineSet's current state.
+                      Known condition types are MachinesReady, MachinesUpToDate, ScalingUp, ScalingDown, Remediating, Deleting, Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                  readyReplicas:
+                    description: readyReplicas is the number of ready replicas for
+                      this MachineSet. A machine is considered ready when Machine's
+                      Ready condition is true.
+                    format: int32
+                    type: integer
+                  upToDateReplicas:
+                    description: upToDateReplicas is the number of up-to-date replicas
+                      for this MachineSet. A machine is considered up-to-date when
+                      Machine's UpToDate condition is true.
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-manager
+  namespace: capi-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-leader-election-role
+  namespace: capi-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      cluster.x-k8s.io/aggregate-to-manager: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-aggregated-manager-role
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/aggregate-to-manager: "true"
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - addons.cluster.x-k8s.io
+  resources:
+  - clusterresourcesets/finalizers
+  - clusterresourcesets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - addons.cluster.x-k8s.io
+  - bootstrap.cluster.x-k8s.io
+  - controlplane.cluster.x-k8s.io
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resourceNames:
+  - clusterclasses.cluster.x-k8s.io
+  - clusterresourcesetbindings.addons.cluster.x-k8s.io
+  - clusterresourcesets.addons.cluster.x-k8s.io
+  - clusters.cluster.x-k8s.io
+  - extensionconfigs.runtime.cluster.x-k8s.io
+  - ipaddressclaims.ipam.cluster.x-k8s.io
+  - ipaddresses.ipam.cluster.x-k8s.io
+  - machinedeployments.cluster.x-k8s.io
+  - machinedrainrules.cluster.x-k8s.io
+  - machinehealthchecks.cluster.x-k8s.io
+  - machinepools.cluster.x-k8s.io
+  - machines.cluster.x-k8s.io
+  - machinesets.cluster.x-k8s.io
+  resources:
+  - customresourcedefinitions
+  - customresourcedefinitions/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusterclasses
+  - clusterclasses/status
+  - clusters
+  - clusters/finalizers
+  - clusters/status
+  - machinedrainrules
+  - machinehealthchecks/finalizers
+  - machinehealthchecks/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  - machinedeployments/finalizers
+  - machinedeployments/status
+  - machinehealthchecks
+  - machinepools
+  - machinepools/finalizers
+  - machinepools/status
+  - machines
+  - machines/finalizers
+  - machines/status
+  - machinesets
+  - machinesets/finalizers
+  - machinesets/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ipam.cluster.x-k8s.io
+  resources:
+  - ipaddressclaims
+  - ipaddresses
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ipam.cluster.x-k8s.io
+  resources:
+  - ipaddressclaims/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - runtime.cluster.x-k8s.io
+  resources:
+  - extensionconfigs
+  - extensionconfigs/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-leader-election-rolebinding
+  namespace: capi-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capi-manager
+  namespace: capi-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-aggregated-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capi-manager
+  namespace: capi-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-webhook-service
+  namespace: capi-system
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    cluster.x-k8s.io/provider: cluster-api
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+    control-plane: controller-manager
+  name: capi-controller-manager
+  namespace: capi-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/provider: cluster-api
+      control-plane: controller-manager
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        cluster.x-k8s.io/provider: cluster-api
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - --diagnostics-address=:8443
+        - --insecure-diagnostics=false
+        - --feature-gates=MachinePool=true,ClusterResourceSet=true,ClusterTopology=true,RuntimeSDK=false,MachineSetPreflightChecks=true,MachineWaitForVolumeDetachConsiderVolumeAttachments=true,PriorityQueue=false
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        image: registry.rancher.com/rancher/cluster-api-controller:v1.10.5
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: capi-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      volumes:
+      - name: cert
+        secret:
+          secretName: capi-webhook-service-cert
+status: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-cluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.cluster.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-clusterclass
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.clusterclass.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterclasses
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-addons-cluster-x-k8s-io-v1beta1-clusterresourceset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.clusterresourceset.addons.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - addons.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterresourcesets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machine
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machine.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machines
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machinedeployment
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machinedeployment.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinedeployments
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machinehealthcheck
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machinehealthcheck.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinehealthchecks
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machineset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machineset.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinesets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-runtime-cluster-x-k8s-io-v1alpha1-extensionconfig
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.extensionconfig.runtime.addons.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - runtime.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - extensionconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machinepool
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machinepool.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinepools
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-cluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.cluster.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - clusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-clusterclass
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.clusterclass.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - clusterclasses
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-addons-cluster-x-k8s-io-v1beta1-clusterresourceset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.clusterresourceset.addons.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - addons.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterresourcesets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-addons-cluster-x-k8s-io-v1beta1-clusterresourcesetbinding
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.clusterresourcesetbinding.addons.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - addons.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterresourcesetbindings
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machine
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machine.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machines
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machinedeployment
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machinedeployment.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinedeployments
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machinedrainrule
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machinedrainrule.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinedrainrules
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machinehealthcheck
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machinehealthcheck.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinehealthchecks
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machineset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machineset.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinesets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-runtime-cluster-x-k8s-io-v1alpha1-extensionconfig
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.extensionconfig.runtime.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - runtime.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - extensionconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machinepool
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machinepool.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinepools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-ipam-cluster-x-k8s-io-v1beta1-ipaddress
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.ipaddress.ipam.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - ipam.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - ipaddresses
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-ipam-cluster-x-k8s-io-v1beta1-ipaddressclaim
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.ipaddressclaim.ipam.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - ipam.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - ipaddressclaims
+  sideEffects: None
+{{- end }}


### PR DESCRIPTION
This PR fetches core CAPI v1.10.5 components manifest from release and embeds the template in the Turtles chart for a simplified air-gapped installation.