### PR TITLE
chore: embed core CAPI provider v1.10.6 manifest in chart

### DIFF
--- a/charts/rancher-turtles/templates/core-provider-configmap.yaml
+++ b/charts/rancher-turtles/templates/core-provider-configmap.yaml
@@ -1,0 +1,2 @@
+{{- if and (index .Values "cluster-api-operator" "cluster-api" "enabled") (index .Values "airGapped") }}
+{{- end }}


### PR DESCRIPTION
This PR fetches core CAPI v1.10.6 components manifest from release and embeds the template in the Turtles chart for a simplified air-gapped installation.